### PR TITLE
Refactor tests with consistent naming

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -10,11 +10,11 @@ import (
 
 func TestCreateDefault(t *testing.T) {
 	cfg := CreateDefault()
-	
+
 	if cfg == nil {
 		t.Error("CreateDefault should return a non-nil config")
 	}
-	
+
 	if cfg.Provider == "" {
 		t.Error("Default config should have a provider set")
 	}
@@ -29,30 +29,30 @@ func TestDetermineProvider(t *testing.T) {
 	}{
 		{
 			name:     "PLEASE_PROVIDER set to ollama",
-			envVar:   "PLEASE_PROVIDER", 
+			envVar:   "PLEASE_PROVIDER",
 			envValue: "ollama",
 			want:     "ollama",
 		},
 		{
 			name:     "PLEASE_PROVIDER set to openai",
 			envVar:   "PLEASE_PROVIDER",
-			envValue: "openai", 
+			envValue: "openai",
 			want:     "openai",
 		},
 	}
-	
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Clean environment first
 			os.Unsetenv("PLEASE_PROVIDER")
-			
+
 			// Set the test environment variable
 			os.Setenv(tt.envVar, tt.envValue)
 			defer os.Unsetenv(tt.envVar)
-			
+
 			cfg := CreateDefault()
 			got := DetermineProvider(cfg)
-			
+
 			if got != tt.want {
 				t.Errorf("DetermineProvider() = %v, want %v", got, tt.want)
 			}
@@ -62,9 +62,9 @@ func TestDetermineProvider(t *testing.T) {
 
 func TestDetermineScriptType(t *testing.T) {
 	cfg := &types.Config{}
-	
+
 	scriptType := DetermineScriptType(cfg)
-	
+
 	// Should return a valid script type
 	validTypes := []string{"powershell", "bash", "zsh", "sh"}
 	found := false
@@ -74,7 +74,7 @@ func TestDetermineScriptType(t *testing.T) {
 			break
 		}
 	}
-	
+
 	if !found {
 		t.Errorf("DetermineScriptType() returned invalid type: %s", scriptType)
 	}
@@ -84,25 +84,25 @@ func TestLoadSave(t *testing.T) {
 	// Test creating default config
 	cfg := CreateDefault()
 	cfg.Provider = "test-provider"
-	
+
 	// Save should not panic or error for basic functionality
 	err := Save(cfg)
 	if err != nil {
 		t.Logf("Save returned error (expected in test environment): %v", err)
 	}
-	
+
 	// Load should return some config even if file doesn't exist
 	loadedCfg, err := Load()
 	if err != nil {
 		t.Logf("Load returned error (expected in test environment): %v", err)
 	}
-	
+
 	if loadedCfg == nil {
 		t.Error("Load should return a config even on error")
 	}
 }
 
-func Test_when_environment_variables_set_should_override_config_values(t *testing.T) {
+func Test_when_environment_variables_set_then_override_config_values(t *testing.T) {
 	// Test environment variable overrides
 	testCases := []struct {
 		name   string
@@ -118,7 +118,7 @@ func Test_when_environment_variables_set_should_override_config_values(t *testin
 		},
 		{
 			name:   "ANTHROPIC_API_KEY override",
-			envVar: "ANTHROPIC_API_KEY", 
+			envVar: "ANTHROPIC_API_KEY",
 			envVal: "test-anthropic-key",
 			check:  func(cfg *types.Config) bool { return cfg.AnthropicAPIKey == "test-anthropic-key" },
 		},
@@ -135,16 +135,16 @@ func Test_when_environment_variables_set_should_override_config_values(t *testin
 			check:  func(cfg *types.Config) bool { return cfg.ScriptType == "bash" },
 		},
 	}
-	
+
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			// Set environment variable
 			t.Setenv(tc.envVar, tc.envVal)
-			
+
 			// Create default config and apply environment overrides
 			cfg := CreateDefault()
 			overrideWithEnvironment(cfg)
-			
+
 			// Check if override was applied
 			if !tc.check(cfg) {
 				t.Errorf("Environment variable %s was not properly applied", tc.envVar)
@@ -153,7 +153,7 @@ func Test_when_environment_variables_set_should_override_config_values(t *testin
 	}
 }
 
-func Test_when_determining_provider_should_respect_fallback_hierarchy(t *testing.T) {
+func Test_when_determining_provider_then_respect_fallback_hierarchy(t *testing.T) {
 	tests := []struct {
 		name             string
 		envProvider      string
@@ -179,20 +179,20 @@ func Test_when_determining_provider_should_respect_fallback_hierarchy(t *testing
 			expectedProvider: "ollama",
 		},
 	}
-	
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Clean environment
 			os.Unsetenv("PLEASE_PROVIDER")
-			
+
 			// Set environment if specified
 			if tt.envProvider != "" {
 				t.Setenv("PLEASE_PROVIDER", tt.envProvider)
 			}
-			
+
 			// Create config with specified provider
 			cfg := &types.Config{Provider: tt.configProvider}
-			
+
 			result := DetermineProvider(cfg)
 			if result != tt.expectedProvider {
 				t.Errorf("DetermineProvider() = %s, want %s", result, tt.expectedProvider)
@@ -201,7 +201,7 @@ func Test_when_determining_provider_should_respect_fallback_hierarchy(t *testing
 	}
 }
 
-func Test_when_determining_script_type_should_handle_explicit_settings(t *testing.T) {
+func Test_when_determining_script_type_then_handle_explicit_settings(t *testing.T) {
 	tests := []struct {
 		name           string
 		configType     string
@@ -213,7 +213,7 @@ func Test_when_determining_script_type_should_handle_explicit_settings(t *testin
 			expectedResult: "powershell",
 		},
 		{
-			name:           "Explicit bash setting", 
+			name:           "Explicit bash setting",
 			configType:     "bash",
 			expectedResult: "bash",
 		},
@@ -228,12 +228,12 @@ func Test_when_determining_script_type_should_handle_explicit_settings(t *testin
 			expectedResult: "", // Will be platform-specific
 		},
 	}
-	
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := &types.Config{ScriptType: tt.configType}
 			result := DetermineScriptType(cfg)
-			
+
 			if tt.expectedResult != "" {
 				// Check explicit expected result
 				if result != tt.expectedResult {
@@ -257,9 +257,9 @@ func Test_when_determining_script_type_should_handle_explicit_settings(t *testin
 	}
 }
 
-func Test_when_creating_default_config_should_initialize_all_required_fields(t *testing.T) {
+func Test_when_creating_default_config_then_initialize_all_required_fields(t *testing.T) {
 	cfg := CreateDefault()
-	
+
 	tests := []struct {
 		name  string
 		check func() bool
@@ -291,7 +291,7 @@ func Test_when_creating_default_config_should_initialize_all_required_fields(t *
 			desc:  "CustomProviders map should be initialized",
 		},
 	}
-	
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if !tt.check() {
@@ -301,17 +301,17 @@ func Test_when_creating_default_config_should_initialize_all_required_fields(t *
 	}
 }
 
-func Test_when_loading_config_should_handle_missing_file_gracefully(t *testing.T) {
+func Test_when_loading_config_then_handle_missing_file_gracefully(t *testing.T) {
 	// This test verifies that Load() returns a default config when file doesn't exist
 	// Note: This may actually try to read from real config locations, so we handle that
-	
+
 	cfg, err := Load()
-	
+
 	// Should always return a config, even if file doesn't exist
 	if cfg == nil {
 		t.Error("Load() should return a config even when file doesn't exist")
 	}
-	
+
 	// Error is acceptable (file may not exist), but config should be valid
 	if cfg != nil {
 		if cfg.ModelOverrides == nil {
@@ -321,25 +321,25 @@ func Test_when_loading_config_should_handle_missing_file_gracefully(t *testing.T
 			t.Error("Loaded config should have initialized CustomProviders")
 		}
 	}
-	
+
 	// Log error for debugging but don't fail test
 	if err != nil {
 		t.Logf("Load returned error (acceptable): %v", err)
 	}
 }
 
-func Test_when_config_has_platform_specific_behavior_should_work_cross_platform(t *testing.T) {
+func Test_when_config_has_platform_specific_behavior_then_work_cross_platform(t *testing.T) {
 	// Test that getConfigPath works on current platform
 	configPath, err := getConfigPath()
-	
+
 	if err != nil {
 		t.Errorf("getConfigPath() should not error on supported platforms: %v", err)
 	}
-	
+
 	if configPath == "" {
 		t.Error("getConfigPath() should return non-empty path")
 	}
-	
+
 	// Path should end with config.json
 	if !strings.HasSuffix(configPath, "config.json") {
 		t.Errorf("Config path should end with 'config.json', got: %s", configPath)

--- a/localization/manager_test.go
+++ b/localization/manager_test.go
@@ -112,7 +112,7 @@ func TestLocalizationSystemGet(t *testing.T) {
 	}
 }
 
-func TestWhenLoadFromFile_ShouldParseLocalizationConfig(t *testing.T) {
+func Test_when_load_from_file_then_parse_localization_config(t *testing.T) {
 	temp := t.TempDir()
 	jsonPath := filepath.Join(temp, "test.json")
 	content := `{
@@ -136,7 +136,7 @@ func TestWhenLoadFromFile_ShouldParseLocalizationConfig(t *testing.T) {
 	}
 }
 
-func TestWhenManagerSwitchesLanguage_ShouldReturnNewMessage(t *testing.T) {
+func Test_when_manager_switches_language_then_return_new_message(t *testing.T) {
 	temp := t.TempDir()
 	enPath := filepath.Join(temp, "en-us.json")
 	esPath := filepath.Join(temp, "es-es.json")
@@ -154,7 +154,7 @@ func TestWhenManagerSwitchesLanguage_ShouldReturnNewMessage(t *testing.T) {
 	}
 }
 
-func TestWhenManagerSwitchesTheme_ShouldReturnNewColor(t *testing.T) {
+func Test_when_manager_switches_theme_then_return_new_color(t *testing.T) {
 	mgr := &LocalizationManager{config: &types.LocalizationConfig{Themes: types.Theme{Colors: map[string]string{"primary": "#fff"}}}}
 	mgr.themes = map[string]types.Theme{"dark": {Colors: map[string]string{"primary": "#000"}}}
 	if mgr.GetThemeColor("primary") != "#fff" {
@@ -166,7 +166,7 @@ func TestWhenManagerSwitchesTheme_ShouldReturnNewColor(t *testing.T) {
 	}
 }
 
-func TestWhenGettingMissingMessage_ShouldUseFallback(t *testing.T) {
+func Test_when_getting_missing_message_then_use_fallback(t *testing.T) {
 	mgr := &LocalizationManager{config: &types.LocalizationConfig{Messages: types.Messages{Banner: types.Banner{Title: "hi"}}}, fallback: &types.LocalizationConfig{Messages: types.Messages{Banner: types.Banner{Title: "fallback"}}}}
 	if mgr.GetMessage("banner.subtitle") != "" {
 		t.Errorf("expected empty string for missing message")

--- a/main_test.go
+++ b/main_test.go
@@ -2,13 +2,13 @@ package main
 
 import (
 	"os"
+	"please/types"
 	"strings"
 	"testing"
-	"please/types"
 )
 
 // Test getFallbackModel function
-func Test_when_provider_is_openai_should_return_gpt_3_5_turbo(t *testing.T) {
+func Test_when_provider_is_openai_then_return_gpt_3_5_turbo(t *testing.T) {
 	// Arrange
 	provider := "openai"
 	expected := "gpt-3.5-turbo"
@@ -22,7 +22,7 @@ func Test_when_provider_is_openai_should_return_gpt_3_5_turbo(t *testing.T) {
 	}
 }
 
-func Test_when_provider_is_anthropic_should_return_claude_3_haiku(t *testing.T) {
+func Test_when_provider_is_anthropic_then_return_claude_3_haiku(t *testing.T) {
 	// Arrange
 	provider := "anthropic"
 	expected := "claude-3-haiku-20240307"
@@ -36,7 +36,7 @@ func Test_when_provider_is_anthropic_should_return_claude_3_haiku(t *testing.T) 
 	}
 }
 
-func Test_when_provider_is_unknown_should_return_llama3_2(t *testing.T) {
+func Test_when_provider_is_unknown_then_return_llama3_2(t *testing.T) {
 	// Arrange
 	provider := "unknown"
 	expected := "llama3.2"
@@ -50,7 +50,7 @@ func Test_when_provider_is_unknown_should_return_llama3_2(t *testing.T) {
 	}
 }
 
-func Test_when_provider_is_ollama_should_return_llama3_2(t *testing.T) {
+func Test_when_provider_is_ollama_then_return_llama3_2(t *testing.T) {
 	// Arrange
 	provider := "ollama"
 	expected := "llama3.2"
@@ -65,7 +65,7 @@ func Test_when_provider_is_ollama_should_return_llama3_2(t *testing.T) {
 }
 
 // Test isLastScriptCommand function
-func Test_when_command_is_run_last_script_should_return_true(t *testing.T) {
+func Test_when_command_is_run_last_script_then_return_true(t *testing.T) {
 	// Arrange
 	command := "run last script"
 
@@ -78,7 +78,7 @@ func Test_when_command_is_run_last_script_should_return_true(t *testing.T) {
 	}
 }
 
-func Test_when_command_is_run_my_last_script_should_return_true(t *testing.T) {
+func Test_when_command_is_run_my_last_script_then_return_true(t *testing.T) {
 	// Arrange
 	command := "run my last script"
 
@@ -91,7 +91,7 @@ func Test_when_command_is_run_my_last_script_should_return_true(t *testing.T) {
 	}
 }
 
-func Test_when_command_is_repeat_should_return_true(t *testing.T) {
+func Test_when_command_is_repeat_then_return_true(t *testing.T) {
 	// Arrange
 	command := "repeat"
 
@@ -104,7 +104,7 @@ func Test_when_command_is_repeat_should_return_true(t *testing.T) {
 	}
 }
 
-func Test_when_command_is_case_insensitive_run_last_script_should_return_true(t *testing.T) {
+func Test_when_command_is_case_insensitive_run_last_script_then_return_true(t *testing.T) {
 	// Arrange
 	command := "RUN LAST SCRIPT"
 
@@ -117,7 +117,7 @@ func Test_when_command_is_case_insensitive_run_last_script_should_return_true(t 
 	}
 }
 
-func Test_when_command_is_do_it_again_should_return_true(t *testing.T) {
+func Test_when_command_is_do_it_again_then_return_true(t *testing.T) {
 	// Arrange
 	command := "do it again"
 
@@ -130,7 +130,7 @@ func Test_when_command_is_do_it_again_should_return_true(t *testing.T) {
 	}
 }
 
-func Test_when_command_is_normal_task_should_return_false(t *testing.T) {
+func Test_when_command_is_normal_task_then_return_false(t *testing.T) {
 	// Arrange
 	command := "list all files in current directory"
 
@@ -143,7 +143,7 @@ func Test_when_command_is_normal_task_should_return_false(t *testing.T) {
 	}
 }
 
-func Test_when_command_is_empty_should_return_false(t *testing.T) {
+func Test_when_command_is_empty_then_return_false(t *testing.T) {
 	// Arrange
 	command := ""
 
@@ -156,7 +156,7 @@ func Test_when_command_is_empty_should_return_false(t *testing.T) {
 	}
 }
 
-func Test_when_command_contains_last_script_pattern_with_extra_words_should_return_true(t *testing.T) {
+func Test_when_command_contains_last_script_pattern_with_extra_words_then_return_true(t *testing.T) {
 	// Arrange
 	command := "please run my last script now"
 
@@ -170,7 +170,7 @@ func Test_when_command_contains_last_script_pattern_with_extra_words_should_retu
 }
 
 // Test generateScript function error cases
-func Test_when_generateScript_receives_unsupported_provider_should_return_error(t *testing.T) {
+func Test_when_generateScript_receives_unsupported_provider_then_return_error(t *testing.T) {
 	// Arrange
 	cfg := &types.Config{}
 	request := &types.ScriptRequest{
@@ -190,7 +190,7 @@ func Test_when_generateScript_receives_unsupported_provider_should_return_error(
 	}
 }
 
-func Test_when_generateScript_receives_empty_provider_should_return_error(t *testing.T) {
+func Test_when_generateScript_receives_empty_provider_then_return_error(t *testing.T) {
 	// Arrange
 	cfg := &types.Config{}
 	request := &types.ScriptRequest{
@@ -211,7 +211,7 @@ func Test_when_generateScript_receives_empty_provider_should_return_error(t *tes
 }
 
 // Test additional isLastScriptCommand patterns
-func Test_when_command_is_execute_my_last_script_should_return_true(t *testing.T) {
+func Test_when_command_is_execute_my_last_script_then_return_true(t *testing.T) {
 	// Arrange
 	command := "execute my last script"
 
@@ -224,7 +224,7 @@ func Test_when_command_is_execute_my_last_script_should_return_true(t *testing.T
 	}
 }
 
-func Test_when_command_is_run_the_last_script_should_return_true(t *testing.T) {
+func Test_when_command_is_run_the_last_script_then_return_true(t *testing.T) {
 	// Arrange
 	command := "run the last script"
 
@@ -237,7 +237,7 @@ func Test_when_command_is_run_the_last_script_should_return_true(t *testing.T) {
 	}
 }
 
-func Test_when_command_is_previous_script_should_return_true(t *testing.T) {
+func Test_when_command_is_previous_script_then_return_true(t *testing.T) {
 	// Arrange
 	command := "previous script"
 
@@ -250,7 +250,7 @@ func Test_when_command_is_previous_script_should_return_true(t *testing.T) {
 	}
 }
 
-func Test_when_command_is_run_again_should_return_true(t *testing.T) {
+func Test_when_command_is_run_again_then_return_true(t *testing.T) {
 	// Arrange
 	command := "run again"
 
@@ -263,7 +263,7 @@ func Test_when_command_is_run_again_should_return_true(t *testing.T) {
 	}
 }
 
-func Test_when_command_is_repeat_last_should_return_true(t *testing.T) {
+func Test_when_command_is_repeat_last_then_return_true(t *testing.T) {
 	// Arrange
 	command := "repeat last"
 
@@ -276,7 +276,7 @@ func Test_when_command_is_repeat_last_should_return_true(t *testing.T) {
 	}
 }
 
-func Test_when_command_is_mixed_case_do_it_again_should_return_true(t *testing.T) {
+func Test_when_command_is_mixed_case_do_it_again_then_return_true(t *testing.T) {
 	// Arrange
 	command := "Do It Again"
 
@@ -289,7 +289,7 @@ func Test_when_command_is_mixed_case_do_it_again_should_return_true(t *testing.T
 	}
 }
 
-func Test_when_command_contains_last_script_substring_should_return_true(t *testing.T) {
+func Test_when_command_contains_last_script_substring_then_return_true(t *testing.T) {
 	// Arrange
 	command := "I want to run my last script please"
 
@@ -303,7 +303,7 @@ func Test_when_command_contains_last_script_substring_should_return_true(t *test
 }
 
 // Test isLastScriptCommand edge cases
-func Test_when_command_is_just_whitespace_should_return_false(t *testing.T) {
+func Test_when_command_is_just_whitespace_then_return_false(t *testing.T) {
 	// Arrange
 	command := "   \t  \n  "
 
@@ -316,7 +316,7 @@ func Test_when_command_is_just_whitespace_should_return_false(t *testing.T) {
 	}
 }
 
-func Test_when_command_contains_script_but_not_last_pattern_should_return_false(t *testing.T) {
+func Test_when_command_contains_script_but_not_last_pattern_then_return_false(t *testing.T) {
 	// Arrange
 	command := "create a new script for me"
 
@@ -329,7 +329,7 @@ func Test_when_command_contains_script_but_not_last_pattern_should_return_false(
 	}
 }
 
-func Test_when_command_contains_run_but_not_last_pattern_should_return_false(t *testing.T) {
+func Test_when_command_contains_run_but_not_last_pattern_then_return_false(t *testing.T) {
 	// Arrange
 	command := "run a system check"
 
@@ -343,7 +343,7 @@ func Test_when_command_contains_run_but_not_last_pattern_should_return_false(t *
 }
 
 // Test generateScript with different provider types
-func Test_when_generateScript_receives_ollama_provider_but_not_configured_should_return_error(t *testing.T) {
+func Test_when_generateScript_receives_ollama_provider_but_not_configured_then_return_error(t *testing.T) {
 	// Arrange
 	cfg := &types.Config{
 		OllamaURL: "", // Not configured
@@ -375,7 +375,7 @@ func Test_when_generateScript_receives_ollama_provider_but_not_configured_should
 	}
 }
 
-func Test_when_generateScript_receives_openai_provider_but_not_configured_should_return_error(t *testing.T) {
+func Test_when_generateScript_receives_openai_provider_but_not_configured_then_return_error(t *testing.T) {
 	// Arrange
 	cfg := &types.Config{
 		OpenAIAPIKey: "", // Not configured
@@ -398,7 +398,7 @@ func Test_when_generateScript_receives_openai_provider_but_not_configured_should
 	}
 }
 
-func Test_when_generateScript_receives_anthropic_provider_but_not_configured_should_return_error(t *testing.T) {
+func Test_when_generateScript_receives_anthropic_provider_but_not_configured_then_return_error(t *testing.T) {
 	// Arrange
 	cfg := &types.Config{
 		AnthropicAPIKey: "", // Not configured
@@ -422,7 +422,7 @@ func Test_when_generateScript_receives_anthropic_provider_but_not_configured_sho
 }
 
 // Test edge cases for getFallbackModel
-func Test_when_provider_is_empty_string_should_return_llama3_2(t *testing.T) {
+func Test_when_provider_is_empty_string_then_return_llama3_2(t *testing.T) {
 	// Arrange
 	provider := ""
 	expected := "llama3.2"
@@ -436,7 +436,7 @@ func Test_when_provider_is_empty_string_should_return_llama3_2(t *testing.T) {
 	}
 }
 
-func Test_when_provider_is_mixed_case_openai_should_return_llama3_2(t *testing.T) {
+func Test_when_provider_is_mixed_case_openai_then_return_llama3_2(t *testing.T) {
 	// Arrange - case sensitivity test
 	provider := "OpenAI"
 	expected := "llama3.2" // Should use default since it's case sensitive
@@ -450,7 +450,7 @@ func Test_when_provider_is_mixed_case_openai_should_return_llama3_2(t *testing.T
 	}
 }
 
-func Test_when_provider_has_extra_spaces_should_return_llama3_2(t *testing.T) {
+func Test_when_provider_has_extra_spaces_then_return_llama3_2(t *testing.T) {
 	// Arrange
 	provider := " openai "
 	expected := "llama3.2" // Should use default since exact match required
@@ -465,10 +465,10 @@ func Test_when_provider_has_extra_spaces_should_return_llama3_2(t *testing.T) {
 }
 
 // Test helper function to verify all patterns are covered
-func Test_when_checking_all_last_script_patterns_should_return_true(t *testing.T) {
+func Test_when_checking_all_last_script_patterns_then_return_true(t *testing.T) {
 	patterns := []string{
 		"run my last script",
-		"run last script", 
+		"run last script",
 		"execute my last script",
 		"execute last script",
 		"run the last script",
@@ -477,7 +477,7 @@ func Test_when_checking_all_last_script_patterns_should_return_true(t *testing.T
 		"run previous script",
 		"run last",
 		"last script",
-		"previous script", 
+		"previous script",
 		"run again",
 		"do it again",
 		"repeat last",
@@ -498,7 +498,7 @@ func Test_when_checking_all_last_script_patterns_should_return_true(t *testing.T
 }
 
 // Test that we handle unusual input gracefully
-func Test_when_command_is_very_long_string_should_handle_gracefully(t *testing.T) {
+func Test_when_command_is_very_long_string_then_handle_gracefully(t *testing.T) {
 	// Arrange - create a very long string without last script patterns
 	command := strings.Repeat("create many files and process data ", 100)
 
@@ -511,7 +511,7 @@ func Test_when_command_is_very_long_string_should_handle_gracefully(t *testing.T
 	}
 }
 
-func Test_when_command_contains_unicode_characters_should_handle_gracefully(t *testing.T) {
+func Test_when_command_contains_unicode_characters_then_handle_gracefully(t *testing.T) {
 	// Arrange
 	command := "运行最后一个脚本" // "run last script" in Chinese
 
@@ -525,11 +525,11 @@ func Test_when_command_contains_unicode_characters_should_handle_gracefully(t *t
 }
 
 // Test OS-related edge cases
-func Test_when_checking_environment_executable_name_should_not_panic(t *testing.T) {
+func Test_when_checking_environment_executable_name_then_not_panic(t *testing.T) {
 	// This test ensures we can call os.Args safely in test environment
 	// Since we can't easily test main() directly, we at least verify
 	// that accessing os.Args doesn't cause issues
-	
+
 	// Arrange & Act - access os.Args similar to main function
 	programName := "test"
 	if len(os.Args) > 0 {

--- a/models/selection_test.go
+++ b/models/selection_test.go
@@ -22,7 +22,7 @@ func TestSelectBestModel(t *testing.T) {
 		},
 		{
 			name:           "Anthropic provider coding task",
-			provider:       "anthropic", 
+			provider:       "anthropic",
 			taskDesc:       "write a function",
 			expectedResult: true,
 		},
@@ -41,9 +41,9 @@ func TestSelectBestModel(t *testing.T) {
 				ModelOverrides:  make(map[string]string),
 				CustomProviders: make(map[string]types.ProviderConfig),
 			}
-			
+
 			result, err := SelectBestModel(cfg, tt.taskDesc, tt.provider)
-			
+
 			if tt.expectedResult {
 				if err != nil {
 					t.Errorf("SelectBestModel should not error for %s provider: %v", tt.provider, err)
@@ -69,13 +69,13 @@ func TestSelectBestModelWithOverrides(t *testing.T) {
 		},
 		CustomProviders: make(map[string]types.ProviderConfig),
 	}
-	
+
 	result, err := SelectBestModel(cfg, "write a script to test", "openai")
-	
+
 	if err != nil {
 		t.Fatalf("SelectBestModel should not error: %v", err)
 	}
-	
+
 	// Should use the override for coding tasks
 	if result != "custom-coding-model" {
 		t.Errorf("SelectBestModel should use override model, got %s", result)
@@ -118,7 +118,7 @@ func TestCategorizeTask(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			result := CategorizeTask(tt.description)
-			
+
 			if result != tt.expected {
 				t.Errorf("CategorizeTask(%s) = %s, want %s", tt.description, result, tt.expected)
 			}
@@ -147,7 +147,7 @@ func TestSelectOpenAIModel(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			result := SelectOpenAIModel(tt.taskType)
-			
+
 			if result != tt.expected {
 				t.Errorf("SelectOpenAIModel(%s) = %s, want %s", tt.taskType, result, tt.expected)
 			}
@@ -167,7 +167,7 @@ func TestSelectAnthropicModel(t *testing.T) {
 			expected: "claude-3-sonnet-20240229",
 		},
 		{
-			name:     "General task uses Claude Haiku", 
+			name:     "General task uses Claude Haiku",
 			taskType: "general",
 			expected: "claude-3-haiku-20240307",
 		},
@@ -176,7 +176,7 @@ func TestSelectAnthropicModel(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			result := SelectAnthropicModel(tt.taskType)
-			
+
 			if result != tt.expected {
 				t.Errorf("SelectAnthropicModel(%s) = %s, want %s", tt.taskType, result, tt.expected)
 			}
@@ -184,46 +184,46 @@ func TestSelectAnthropicModel(t *testing.T) {
 	}
 }
 
-func Test_when_ranking_models_should_return_best_match_for_task_type(t *testing.T) {
+func Test_when_ranking_models_then_return_best_match_for_task_type(t *testing.T) {
 	models := []types.ModelInfo{
 		{Name: "llama3.2:latest"},
 		{Name: "deepseek-coder:6.7b"},
 		{Name: "codellama:7b"},
 		{Name: "mistral:7b"},
 	}
-	
+
 	// Test coding task should prefer coding-optimized models
 	result := RankModels(models, "write a Python script", "coding")
-	
+
 	// Should prefer coding-specific models
 	if !strings.Contains(result, "coder") && !strings.Contains(result, "codellama") {
 		t.Errorf("Expected coding-optimized model for coding task, got: %s", result)
 	}
 }
 
-func Test_when_ranking_models_with_empty_list_should_return_empty_string(t *testing.T) {
+func Test_when_ranking_models_with_empty_list_then_return_empty_string(t *testing.T) {
 	models := []types.ModelInfo{}
-	
+
 	result := RankModels(models, "any task", "general")
-	
+
 	if result != "" {
 		t.Errorf("Expected empty string for empty model list, got: %s", result)
 	}
 }
 
-func Test_when_ranking_models_should_handle_general_tasks(t *testing.T) {
+func Test_when_ranking_models_then_handle_general_tasks(t *testing.T) {
 	models := []types.ModelInfo{
 		{Name: "llama3.2:latest"},
 		{Name: "mistral:7b"},
 	}
-	
+
 	result := RankModels(models, "help me organize files", "general")
-	
+
 	// Should return a non-empty model name
 	if result == "" {
 		t.Error("Expected non-empty model name for general task")
 	}
-	
+
 	// Should be one of the available models
 	found := false
 	for _, model := range models {
@@ -237,28 +237,28 @@ func Test_when_ranking_models_should_handle_general_tasks(t *testing.T) {
 	}
 }
 
-func Test_when_environment_variable_set_should_override_model_selection(t *testing.T) {
+func Test_when_environment_variable_set_then_override_model_selection(t *testing.T) {
 	// Set environment variable
 	t.Setenv("OLLAMA_MODEL", "custom-env-model")
-	
+
 	cfg := &types.Config{
 		Provider:        "ollama",
 		ModelOverrides:  make(map[string]string),
 		CustomProviders: make(map[string]types.ProviderConfig),
 	}
-	
+
 	result, err := SelectBestModel(cfg, "any task", "ollama")
-	
+
 	if err != nil {
 		t.Fatalf("SelectBestModel should not error: %v", err)
 	}
-	
+
 	if result != "custom-env-model" {
 		t.Errorf("Expected environment variable override 'custom-env-model', got '%s'", result)
 	}
 }
 
-func Test_when_custom_provider_with_model_should_use_configured_model(t *testing.T) {
+func Test_when_custom_provider_with_model_then_use_configured_model(t *testing.T) {
 	cfg := &types.Config{
 		Provider:       "custom-provider",
 		ModelOverrides: make(map[string]string),
@@ -270,19 +270,19 @@ func Test_when_custom_provider_with_model_should_use_configured_model(t *testing
 			},
 		},
 	}
-	
+
 	result, err := SelectBestModel(cfg, "test task", "custom-provider")
-	
+
 	if err != nil {
 		t.Fatalf("SelectBestModel should not error for custom provider: %v", err)
 	}
-	
+
 	if result != "custom-model" {
 		t.Errorf("Expected custom provider model 'custom-model', got '%s'", result)
 	}
 }
 
-func Test_when_custom_provider_without_model_should_error(t *testing.T) {
+func Test_when_custom_provider_without_model_then_error(t *testing.T) {
 	cfg := &types.Config{
 		Provider:       "custom-provider",
 		ModelOverrides: make(map[string]string),
@@ -294,48 +294,48 @@ func Test_when_custom_provider_without_model_should_error(t *testing.T) {
 			},
 		},
 	}
-	
+
 	_, err := SelectBestModel(cfg, "test task", "custom-provider")
-	
+
 	if err == nil {
 		t.Error("SelectBestModel should error when custom provider has no model configured")
 	}
-	
+
 	if !strings.Contains(err.Error(), "no model configured") {
 		t.Errorf("Error should mention 'no model configured', got: %v", err)
 	}
 }
 
-func Test_when_ranking_models_should_prefer_larger_models(t *testing.T) {
+func Test_when_ranking_models_then_prefer_larger_models(t *testing.T) {
 	models := []types.ModelInfo{
-		{Name: "small-model", Size: 2000000000}, // 2GB
-		{Name: "large-model", Size: 8000000000}, // 8GB
+		{Name: "small-model", Size: 2000000000},  // 2GB
+		{Name: "large-model", Size: 8000000000},  // 8GB
 		{Name: "medium-model", Size: 5000000000}, // 5GB
 	}
-	
+
 	result := RankModels(models, "general task", "general")
-	
+
 	// Should prefer the larger model
 	if result != "large-model" {
 		t.Errorf("Expected larger model to be preferred, got: %s", result)
 	}
 }
 
-func Test_when_ranking_models_should_boost_coding_models_for_coding_tasks(t *testing.T) {
+func Test_when_ranking_models_then_boost_coding_models_for_coding_tasks(t *testing.T) {
 	models := []types.ModelInfo{
 		{Name: "llama3.2", Size: 7000000000},
 		{Name: "codellama", Size: 6000000000}, // Smaller but coding-focused
 	}
-	
+
 	result := RankModels(models, "write a function", "coding")
-	
+
 	// Should prefer the coding model despite smaller size
 	if result != "codellama" {
 		t.Errorf("Expected coding model to be preferred for coding task, got: %s", result)
 	}
 }
 
-func Test_when_categorizing_task_should_handle_case_insensitive_matching(t *testing.T) {
+func Test_when_categorizing_task_then_handle_case_insensitive_matching(t *testing.T) {
 	tests := []struct {
 		description string
 		expected    string
@@ -345,7 +345,7 @@ func Test_when_categorizing_task_should_handle_case_insensitive_matching(t *test
 		{"Install SERVICE on SERVER", "sysadmin"},
 		{"Download from HTTP URL", "network"},
 	}
-	
+
 	for _, tt := range tests {
 		t.Run(tt.description, func(t *testing.T) {
 			result := CategorizeTask(tt.description)
@@ -356,10 +356,10 @@ func Test_when_categorizing_task_should_handle_case_insensitive_matching(t *test
 	}
 }
 
-func Test_when_categorizing_task_should_prioritize_network_over_file_for_download(t *testing.T) {
+func Test_when_categorizing_task_then_prioritize_network_over_file_for_download(t *testing.T) {
 	// Download tasks should be categorized as network, not file management
 	result := CategorizeTask("download files from the web server")
-	
+
 	if result != "network" {
 		t.Errorf("Download tasks should be categorized as network, got: %s", result)
 	}

--- a/providers/provider_test.go
+++ b/providers/provider_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 // Test CreatePrompt function for different script types
-func Test_when_creating_bash_prompt_should_include_bash_specific_elements(t *testing.T) {
+func Test_when_creating_bash_prompt_then_include_bash_specific_elements(t *testing.T) {
 	// Arrange
 	taskDescription := "list all files in current directory"
 	scriptType := "bash"
@@ -31,7 +31,7 @@ func Test_when_creating_bash_prompt_should_include_bash_specific_elements(t *tes
 	}
 }
 
-func Test_when_creating_powershell_prompt_should_include_powershell_specific_elements(t *testing.T) {
+func Test_when_creating_powershell_prompt_then_include_powershell_specific_elements(t *testing.T) {
 	// Arrange
 	taskDescription := "get system information"
 	scriptType := "powershell"
@@ -54,7 +54,7 @@ func Test_when_creating_powershell_prompt_should_include_powershell_specific_ele
 	}
 }
 
-func Test_when_creating_prompt_with_unknown_script_type_should_default_to_powershell(t *testing.T) {
+func Test_when_creating_prompt_with_unknown_script_type_then_default_to_powershell(t *testing.T) {
 	// Arrange
 	taskDescription := "do something"
 	scriptType := "unknown"
@@ -71,7 +71,7 @@ func Test_when_creating_prompt_with_unknown_script_type_should_default_to_powers
 	}
 }
 
-func Test_when_creating_prompt_with_empty_task_description_should_include_empty_task(t *testing.T) {
+func Test_when_creating_prompt_with_empty_task_description_then_include_empty_task(t *testing.T) {
 	// Arrange
 	taskDescription := ""
 	scriptType := "bash"
@@ -89,7 +89,7 @@ func Test_when_creating_prompt_with_empty_task_description_should_include_empty_
 	}
 }
 
-func Test_when_creating_bash_prompt_should_include_safety_requirements(t *testing.T) {
+func Test_when_creating_bash_prompt_then_include_safety_requirements(t *testing.T) {
 	// Arrange
 	taskDescription := "delete files"
 	scriptType := "bash"
@@ -109,7 +109,7 @@ func Test_when_creating_bash_prompt_should_include_safety_requirements(t *testin
 	}
 }
 
-func Test_when_creating_powershell_prompt_should_include_safety_requirements(t *testing.T) {
+func Test_when_creating_powershell_prompt_then_include_safety_requirements(t *testing.T) {
 	// Arrange
 	taskDescription := "modify registry"
 	scriptType := "powershell"
@@ -129,7 +129,7 @@ func Test_when_creating_powershell_prompt_should_include_safety_requirements(t *
 	}
 }
 
-func Test_when_creating_prompt_with_special_characters_should_preserve_them(t *testing.T) {
+func Test_when_creating_prompt_with_special_characters_then_preserve_them(t *testing.T) {
 	// Arrange
 	taskDescription := "find files with name 'test*.txt' & sort by date"
 	scriptType := "bash"
@@ -180,7 +180,7 @@ func (m *MockProvider) IsConfigured(config *types.Config) bool {
 }
 
 // Test GenerateFixedScript function
-func Test_when_generating_fixed_script_with_unsupported_provider_should_return_error(t *testing.T) {
+func Test_when_generating_fixed_script_with_unsupported_provider_then_return_error(t *testing.T) {
 	// Arrange
 	originalScript := "echo 'hello'"
 	errorMessage := "command not found"
@@ -204,7 +204,7 @@ func Test_when_generating_fixed_script_with_unsupported_provider_should_return_e
 	}
 }
 
-func Test_when_generating_fixed_script_should_include_original_script_and_error_in_prompt(t *testing.T) {
+func Test_when_generating_fixed_script_then_include_original_script_and_error_in_prompt(t *testing.T) {
 	// Arrange
 	originalScript := "rm -rf /"
 	errorMessage := "permission denied"
@@ -218,7 +218,7 @@ func Test_when_generating_fixed_script_should_include_original_script_and_error_
 
 	// We can't easily test the actual providers without mocking the HTTP calls
 	// So let's test the error case to verify the flow
-	
+
 	// Act
 	_, err := GenerateFixedScript(originalScript, errorMessage, scriptType, model, provider, config)
 
@@ -231,7 +231,7 @@ func Test_when_generating_fixed_script_should_include_original_script_and_error_
 	}
 }
 
-func Test_when_generating_fixed_script_with_empty_original_script_should_handle_gracefully(t *testing.T) {
+func Test_when_generating_fixed_script_with_empty_original_script_then_handle_gracefully(t *testing.T) {
 	// Arrange
 	originalScript := ""
 	errorMessage := "no script provided"
@@ -253,7 +253,7 @@ func Test_when_generating_fixed_script_with_empty_original_script_should_handle_
 	// Function should not panic with empty inputs
 }
 
-func Test_when_generating_fixed_script_with_anthropic_provider_should_use_anthropic(t *testing.T) {
+func Test_when_generating_fixed_script_with_anthropic_provider_then_use_anthropic(t *testing.T) {
 	// Arrange
 	originalScript := "echo test"
 	errorMessage := "test error"
@@ -261,7 +261,7 @@ func Test_when_generating_fixed_script_with_anthropic_provider_should_use_anthro
 	model := "claude-3"
 	provider := "anthropic"
 	config := &types.Config{
-		Provider:       "anthropic",
+		Provider:        "anthropic",
 		AnthropicAPIKey: "test-key",
 	}
 
@@ -278,7 +278,7 @@ func Test_when_generating_fixed_script_with_anthropic_provider_should_use_anthro
 	}
 }
 
-func Test_when_generating_fixed_script_with_empty_error_message_should_handle_gracefully(t *testing.T) {
+func Test_when_generating_fixed_script_with_empty_error_message_then_handle_gracefully(t *testing.T) {
 	// Arrange
 	originalScript := "echo 'hello world'"
 	errorMessage := ""
@@ -300,7 +300,7 @@ func Test_when_generating_fixed_script_with_empty_error_message_should_handle_gr
 	// Function should not panic with empty error message
 }
 
-func Test_when_generating_fixed_script_prompt_construction_should_include_all_elements(t *testing.T) {
+func Test_when_generating_fixed_script_prompt_construction_then_include_all_elements(t *testing.T) {
 	// This test verifies the prompt construction logic by checking what would be sent
 	// We can't easily intercept the actual prompt without modifying the function,
 	// but we can test the inputs are processed correctly by ensuring the function
@@ -354,7 +354,7 @@ func Test_when_generating_fixed_script_prompt_construction_should_include_all_el
 }
 
 // Provider Instance Tests
-func Test_when_creating_openai_provider_should_initialize_correctly(t *testing.T) {
+func Test_when_creating_openai_provider_then_initialize_correctly(t *testing.T) {
 	// Arrange
 	config := &types.Config{
 		OpenAIAPIKey: "test-key",
@@ -373,7 +373,7 @@ func Test_when_creating_openai_provider_should_initialize_correctly(t *testing.T
 	}
 }
 
-func Test_when_creating_anthropic_provider_should_initialize_correctly(t *testing.T) {
+func Test_when_creating_anthropic_provider_then_initialize_correctly(t *testing.T) {
 	// Arrange
 	config := &types.Config{
 		AnthropicAPIKey: "test-key",
@@ -392,7 +392,7 @@ func Test_when_creating_anthropic_provider_should_initialize_correctly(t *testin
 	}
 }
 
-func Test_when_creating_ollama_provider_should_initialize_correctly(t *testing.T) {
+func Test_when_creating_ollama_provider_then_initialize_correctly(t *testing.T) {
 	// Arrange
 	config := &types.Config{
 		OllamaURL: "http://localhost:11434",
@@ -411,13 +411,13 @@ func Test_when_creating_ollama_provider_should_initialize_correctly(t *testing.T
 	}
 }
 
-func Test_when_checking_openai_configuration_should_validate_api_key(t *testing.T) {
+func Test_when_checking_openai_configuration_then_validate_api_key(t *testing.T) {
 	provider := NewOpenAIProvider(&types.Config{})
 
 	tests := []struct {
-		name      string
-		config    *types.Config
-		expected  bool
+		name     string
+		config   *types.Config
+		expected bool
 	}{
 		{
 			name:     "Valid API key",
@@ -446,13 +446,13 @@ func Test_when_checking_openai_configuration_should_validate_api_key(t *testing.
 	}
 }
 
-func Test_when_checking_anthropic_configuration_should_validate_api_key(t *testing.T) {
+func Test_when_checking_anthropic_configuration_then_validate_api_key(t *testing.T) {
 	provider := NewAnthropicProvider(&types.Config{})
 
 	tests := []struct {
-		name      string
-		config    *types.Config
-		expected  bool
+		name     string
+		config   *types.Config
+		expected bool
 	}{
 		{
 			name:     "Valid API key",
@@ -476,14 +476,14 @@ func Test_when_checking_anthropic_configuration_should_validate_api_key(t *testi
 	}
 }
 
-func Test_when_checking_ollama_configuration_should_always_return_true(t *testing.T) {
+func Test_when_checking_ollama_configuration_then_always_return_true(t *testing.T) {
 	provider := NewOllamaProvider(&types.Config{})
 
 	tests := []struct {
-		name      string
-		config    *types.Config
-		expected  bool
-		desc      string
+		name     string
+		config   *types.Config
+		expected bool
+		desc     string
 	}{
 		{
 			name:     "Valid URL",
@@ -515,7 +515,7 @@ func Test_when_checking_ollama_configuration_should_always_return_true(t *testin
 	}
 }
 
-func Test_when_openai_provider_not_configured_should_return_error(t *testing.T) {
+func Test_when_openai_provider_not_configured_then_return_error(t *testing.T) {
 	// Arrange
 	config := &types.Config{OpenAIAPIKey: ""} // No API key
 	provider := NewOpenAIProvider(config)
@@ -540,7 +540,7 @@ func Test_when_openai_provider_not_configured_should_return_error(t *testing.T) 
 	}
 }
 
-func Test_when_anthropic_provider_not_configured_should_return_error(t *testing.T) {
+func Test_when_anthropic_provider_not_configured_then_return_error(t *testing.T) {
 	// Arrange
 	config := &types.Config{AnthropicAPIKey: ""} // No API key
 	provider := NewAnthropicProvider(config)
@@ -565,7 +565,7 @@ func Test_when_anthropic_provider_not_configured_should_return_error(t *testing.
 	}
 }
 
-func Test_when_getting_openai_available_models_should_return_model_list(t *testing.T) {
+func Test_when_getting_openai_available_models_then_return_model_list(t *testing.T) {
 	// Arrange
 	provider := NewOpenAIProvider(&types.Config{})
 
@@ -576,7 +576,7 @@ func Test_when_getting_openai_available_models_should_return_model_list(t *testi
 	if len(models) == 0 {
 		t.Error("Expected non-empty list of available models")
 	}
-	
+
 	// Check for expected models
 	expectedModels := []string{"gpt-4", "gpt-3.5-turbo"}
 	for _, expected := range expectedModels {
@@ -593,7 +593,7 @@ func Test_when_getting_openai_available_models_should_return_model_list(t *testi
 	}
 }
 
-func Test_when_getting_anthropic_available_models_should_return_model_list(t *testing.T) {
+func Test_when_getting_anthropic_available_models_then_return_model_list(t *testing.T) {
 	// Arrange
 	provider := NewAnthropicProvider(&types.Config{})
 
@@ -604,7 +604,7 @@ func Test_when_getting_anthropic_available_models_should_return_model_list(t *te
 	if len(models) == 0 {
 		t.Error("Expected non-empty list of available models")
 	}
-	
+
 	// Check for Claude models
 	found := false
 	for _, model := range models {
@@ -618,7 +618,7 @@ func Test_when_getting_anthropic_available_models_should_return_model_list(t *te
 	}
 }
 
-func Test_when_testing_provider_interface_implementation_should_satisfy_interface(t *testing.T) {
+func Test_when_testing_provider_interface_implementation_then_satisfy_interface(t *testing.T) {
 	// This test ensures all providers implement the Provider interface correctly
 	configs := []*types.Config{
 		{OpenAIAPIKey: "test"},

--- a/script/autofix_test.go
+++ b/script/autofix_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 // TestGenerateFixedScript_UsesCorrectProvider tests that auto-fix now uses the specified provider
-func TestGenerateFixedScript_UsesCorrectProvider(t *testing.T) {
+func Test_when_generate_fixed_script_then_uses_correct_provider(t *testing.T) {
 	// Test that the function now correctly uses different providers
 
 	originalScript := "echo 'broken script'"
@@ -58,7 +58,7 @@ func TestGenerateFixedScript_UsesCorrectProvider(t *testing.T) {
 }
 
 // TestGenerateFixedScript_ProperPrompt tests that the prompt includes proper context
-func TestGenerateFixedScript_ProperPrompt(t *testing.T) {
+func Test_when_generate_fixed_script_then_proper_prompt(t *testing.T) {
 	var receivedRequest *types.ScriptRequest
 
 	mockProvider := &MockProvider{
@@ -141,8 +141,8 @@ func generateFixedScriptWithProvider(
 	config *types.Config,
 ) (string, error) {
 	// This is what we need to implement to fix the hard-coded OpenAI issue
-	prompt := "The following script failed with this error:\n\nScript:\n" + 
-		originalScript + "\n\nError:\n" + errorMessage + 
+	prompt := "The following script failed with this error:\n\nScript:\n" +
+		originalScript + "\n\nError:\n" + errorMessage +
 		"\n\nPlease suggest a corrected version of the script. Return ONLY the fixed script, no explanations or markdown formatting."
 
 	request := &types.ScriptRequest{

--- a/script/editor_test.go
+++ b/script/editor_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 )
 
-func TestEditScript_NoChange(t *testing.T) {
+func Test_when_edit_script_then_no_change(t *testing.T) {
 	// Prepare a dummy script response
 	resp := &types.ScriptResponse{
 		TaskDescription: "echo hello world",
@@ -52,7 +52,7 @@ func TestEditScript_NoChange(t *testing.T) {
 	}
 }
 
-func TestEditScript_Modified(t *testing.T) {
+func Test_when_edit_script_then_modified(t *testing.T) {
 	resp := &types.ScriptResponse{
 		TaskDescription: "echo hello world",
 		Script:          "echo hello world",

--- a/script/operations_test.go
+++ b/script/operations_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Test GetSuggestedFilename function
-func Test_when_getting_filename_for_bash_script_should_add_sh_extension(t *testing.T) {
+func Test_when_getting_filename_for_bash_script_then_add_sh_extension(t *testing.T) {
 	// Arrange
 	response := &types.ScriptResponse{
 		TaskDescription: "list files in directory",
@@ -33,11 +33,11 @@ func Test_when_getting_filename_for_bash_script_should_add_sh_extension(t *testi
 	}
 }
 
-func Test_when_getting_filename_for_powershell_script_should_add_ps1_extension(t *testing.T) {
+func Test_when_getting_filename_for_powershell_script_then_add_ps1_extension(t *testing.T) {
 	// Arrange
 	response := &types.ScriptResponse{
 		TaskDescription: "get system information",
-		ScriptType:      "powershell", 
+		ScriptType:      "powershell",
 		Script:          "Get-ComputerInfo",
 	}
 
@@ -53,7 +53,7 @@ func Test_when_getting_filename_for_powershell_script_should_add_ps1_extension(t
 	}
 }
 
-func Test_when_getting_filename_with_special_characters_should_normalize_them(t *testing.T) {
+func Test_when_getting_filename_with_special_characters_then_normalize_them(t *testing.T) {
 	// Arrange
 	response := &types.ScriptResponse{
 		TaskDescription: "find files with name test*.txt & sort by date",
@@ -76,7 +76,7 @@ func Test_when_getting_filename_with_special_characters_should_normalize_them(t 
 	}
 }
 
-func Test_when_getting_filename_with_common_words_should_filter_them_out(t *testing.T) {
+func Test_when_getting_filename_with_common_words_then_filter_them_out(t *testing.T) {
 	// Arrange
 	response := &types.ScriptResponse{
 		TaskDescription: "create a backup of the important files and directories",
@@ -96,7 +96,7 @@ func Test_when_getting_filename_with_common_words_should_filter_them_out(t *test
 	}
 }
 
-func Test_when_getting_filename_with_long_description_should_limit_length(t *testing.T) {
+func Test_when_getting_filename_with_long_description_then_limit_length(t *testing.T) {
 	// Arrange
 	longDescription := "this is a very long task description that should be truncated because it exceeds the maximum allowed length for a filename"
 	response := &types.ScriptResponse{
@@ -115,7 +115,7 @@ func Test_when_getting_filename_with_long_description_should_limit_length(t *tes
 	}
 }
 
-func Test_when_getting_filename_with_empty_description_should_use_default(t *testing.T) {
+func Test_when_getting_filename_with_empty_description_then_use_default(t *testing.T) {
 	// Arrange
 	response := &types.ScriptResponse{
 		TaskDescription: "",
@@ -135,7 +135,7 @@ func Test_when_getting_filename_with_empty_description_should_use_default(t *tes
 	}
 }
 
-func Test_when_getting_filename_with_only_short_words_should_use_default(t *testing.T) {
+func Test_when_getting_filename_with_only_short_words_then_use_default(t *testing.T) {
 	// Arrange
 	response := &types.ScriptResponse{
 		TaskDescription: "a to is on at by",
@@ -153,35 +153,35 @@ func Test_when_getting_filename_with_only_short_words_should_use_default(t *test
 }
 
 // Test ValidateScript function
-func Test_when_validating_script_with_critical_dangers_should_return_critical_warnings(t *testing.T) {
+func Test_when_validating_script_with_critical_dangers_then_return_critical_warnings(t *testing.T) {
 	testCases := []struct {
-		name           string
-		script         string
+		name            string
+		script          string
 		expectedWarning string
 	}{
 		{
-			name:           "rm rf root",
-			script:         "rm -rf /",
+			name:            "rm rf root",
+			script:          "rm -rf /",
 			expectedWarning: "⛔ CRITICAL: Attempts to delete entire filesystem",
 		},
 		{
-			name:           "rm rf root with asterisk",
-			script:         "rm -rf /*",
+			name:            "rm rf root with asterisk",
+			script:          "rm -rf /*",
 			expectedWarning: "⛔ CRITICAL: Attempts to delete entire filesystem",
 		},
 		{
-			name:           "windows delete c drive",
-			script:         "del /s /q c:\\*",
+			name:            "windows delete c drive",
+			script:          "del /s /q c:\\*",
 			expectedWarning: "⛔ CRITICAL: Attempts to delete entire C: drive",
 		},
 		{
-			name:           "format c drive",
-			script:         "format c:",
+			name:            "format c drive",
+			script:          "format c:",
 			expectedWarning: "⛔ CRITICAL: Attempts to format C: drive",
 		},
 		{
-			name:           "dd command with zeros",
-			script:         "dd if=/dev/zero of=/dev/sda",
+			name:            "dd command with zeros",
+			script:          "dd if=/dev/zero of=/dev/sda",
 			expectedWarning: "⛔ CRITICAL: Attempts to overwrite data with zeros",
 		},
 	}
@@ -215,7 +215,7 @@ func Test_when_validating_script_with_critical_dangers_should_return_critical_wa
 	}
 }
 
-func Test_when_validating_script_with_high_risk_commands_should_return_high_risk_warnings(t *testing.T) {
+func Test_when_validating_script_with_high_risk_commands_then_return_high_risk_warnings(t *testing.T) {
 	testCases := []struct {
 		name           string
 		script         string
@@ -269,7 +269,7 @@ func Test_when_validating_script_with_high_risk_commands_should_return_high_risk
 	}
 }
 
-func Test_when_validating_script_with_medium_risk_commands_should_return_caution_warnings(t *testing.T) {
+func Test_when_validating_script_with_medium_risk_commands_then_return_caution_warnings(t *testing.T) {
 	testCases := []struct {
 		name           string
 		script         string
@@ -318,7 +318,7 @@ func Test_when_validating_script_with_medium_risk_commands_should_return_caution
 	}
 }
 
-func Test_when_validating_bash_script_without_shebang_should_suggest_adding_it(t *testing.T) {
+func Test_when_validating_bash_script_without_shebang_then_suggest_adding_it(t *testing.T) {
 	// Arrange
 	response := &types.ScriptResponse{
 		Script:     "echo 'hello world'\nls -la",
@@ -341,7 +341,7 @@ func Test_when_validating_bash_script_without_shebang_should_suggest_adding_it(t
 	}
 }
 
-func Test_when_validating_very_short_script_should_warn_about_completeness(t *testing.T) {
+func Test_when_validating_very_short_script_then_warn_about_completeness(t *testing.T) {
 	// Arrange
 	response := &types.ScriptResponse{
 		Script:     "ls",
@@ -364,7 +364,7 @@ func Test_when_validating_very_short_script_should_warn_about_completeness(t *te
 	}
 }
 
-func Test_when_validating_script_without_error_handling_should_suggest_adding_it(t *testing.T) {
+func Test_when_validating_script_without_error_handling_then_suggest_adding_it(t *testing.T) {
 	// Arrange
 	longScriptWithoutErrorHandling := `#!/bin/bash
 echo "Starting process"
@@ -394,7 +394,7 @@ echo "Process complete"`
 	}
 }
 
-func Test_when_validating_script_with_error_handling_should_not_suggest_adding_it(t *testing.T) {
+func Test_when_validating_script_with_error_handling_then_not_suggest_adding_it(t *testing.T) {
 	// Arrange
 	scriptWithErrorHandling := `#!/bin/bash
 if [ ! -f "input.txt" ]; then
@@ -421,7 +421,7 @@ echo "Success"`
 }
 
 // Test containsCommand function
-func Test_when_checking_command_in_quoted_string_should_return_false(t *testing.T) {
+func Test_when_checking_command_in_quoted_string_then_return_false(t *testing.T) {
 	testCases := []struct {
 		name     string
 		script   string
@@ -468,7 +468,7 @@ func Test_when_checking_command_in_quoted_string_should_return_false(t *testing.
 }
 
 // Test containsPatternOutsideQuotes function
-func Test_when_checking_pattern_outside_quotes_should_detect_correctly(t *testing.T) {
+func Test_when_checking_pattern_outside_quotes_then_detect_correctly(t *testing.T) {
 	testCases := []struct {
 		name     string
 		line     string
@@ -521,91 +521,91 @@ func Test_when_checking_pattern_outside_quotes_should_detect_correctly(t *testin
 }
 
 // Test SaveToFile function (safe file operations)
-func Test_when_saving_bash_script_without_extension_should_add_sh_extension(t *testing.T) {
+func Test_when_saving_bash_script_without_extension_then_add_sh_extension(t *testing.T) {
 	// Arrange
 	script := "#!/bin/bash\necho 'test'"
 	filename := "test_script"
-	
+
 	// Act
 	err := SaveToFile(script, filename)
-	
+
 	// Assert
 	if err != nil {
 		t.Errorf("Expected no error saving file, got: %v", err)
 	}
-	
+
 	// Check if file exists with .sh extension
 	if _, err := os.Stat(filename + ".sh"); err != nil {
 		t.Errorf("Expected file %s.sh to exist, got error: %v", filename, err)
 	}
-	
+
 	// Cleanup
 	os.Remove(filename + ".sh")
 }
 
-func Test_when_saving_powershell_script_without_extension_should_add_ps1_extension(t *testing.T) {
+func Test_when_saving_powershell_script_without_extension_then_add_ps1_extension(t *testing.T) {
 	// Arrange
 	script := "Write-Host 'test'"
 	filename := "test_script"
-	
+
 	// Act
 	err := SaveToFile(script, filename)
-	
+
 	// Assert
 	if err != nil {
 		t.Errorf("Expected no error saving file, got: %v", err)
 	}
-	
+
 	// Check if file exists with .ps1 extension
 	if _, err := os.Stat(filename + ".ps1"); err != nil {
 		t.Errorf("Expected file %s.ps1 to exist, got error: %v", filename, err)
 	}
-	
+
 	// Cleanup
 	os.Remove(filename + ".ps1")
 }
 
-func Test_when_saving_script_with_extension_should_preserve_extension(t *testing.T) {
+func Test_when_saving_script_with_extension_then_preserve_extension(t *testing.T) {
 	// Arrange
 	script := "echo 'test'"
 	filename := "myscript.custom"
-	
+
 	// Act
 	err := SaveToFile(script, filename)
-	
+
 	// Assert
 	if err != nil {
 		t.Errorf("Expected no error saving file, got: %v", err)
 	}
-	
+
 	// Check if file exists with original extension
 	if _, err := os.Stat(filename); err != nil {
 		t.Errorf("Expected file %s to exist, got error: %v", filename, err)
 	}
-	
+
 	// Cleanup
 	os.Remove(filename)
 }
 
-func Test_when_saving_bash_script_on_unix_should_make_executable(t *testing.T) {
+func Test_when_saving_bash_script_on_unix_then_make_executable(t *testing.T) {
 	// Skip on Windows
 	if runtime.GOOS == "windows" {
 		t.Skip("Skipping executable test on Windows")
 		return
 	}
-	
+
 	// Arrange
 	script := "#!/bin/bash\necho 'test'"
 	filename := "test_executable.sh"
-	
+
 	// Act
 	err := SaveToFile(script, filename)
-	
+
 	// Assert
 	if err != nil {
 		t.Errorf("Expected no error saving file, got: %v", err)
 	}
-	
+
 	// Check file permissions
 	info, err := os.Stat(filename)
 	if err != nil {
@@ -616,16 +616,16 @@ func Test_when_saving_bash_script_on_unix_should_make_executable(t *testing.T) {
 			t.Errorf("Expected file to be executable, got mode: %v", mode)
 		}
 	}
-	
+
 	// Cleanup
 	os.Remove(filename)
 }
 
 // Test CopyToClipboard function (platform-aware)
-func Test_when_copying_empty_string_to_clipboard_should_not_error(t *testing.T) {
+func Test_when_copying_empty_string_to_clipboard_then_not_error(t *testing.T) {
 	// Act
 	err := CopyToClipboard("")
-	
+
 	// Assert - This might fail if clipboard tools aren't available, but shouldn't panic
 	if err != nil {
 		t.Logf("Clipboard operation failed (expected on some systems): %v", err)
@@ -633,13 +633,13 @@ func Test_when_copying_empty_string_to_clipboard_should_not_error(t *testing.T) 
 	}
 }
 
-func Test_when_copying_text_to_clipboard_should_handle_gracefully(t *testing.T) {
+func Test_when_copying_text_to_clipboard_then_handle_gracefully(t *testing.T) {
 	// Arrange
 	testText := "echo 'Hello, World!'"
-	
+
 	// Act
 	err := CopyToClipboard(testText)
-	
+
 	// Assert - This might fail if clipboard tools aren't available, but shouldn't panic
 	if err != nil {
 		t.Logf("Clipboard operation failed (expected on some systems): %v", err)
@@ -652,7 +652,7 @@ func Test_when_copying_text_to_clipboard_should_handle_gracefully(t *testing.T) 
 }
 
 // Test ExecuteScript function (the major missing coverage area)
-func Test_when_executing_safe_bash_script_should_run_successfully(t *testing.T) {
+func Test_when_executing_safe_bash_script_then_run_successfully(t *testing.T) {
 	// Arrange - Create a safe script that just echoes a test message
 	response := &types.ScriptResponse{
 		Script:          "#!/bin/bash\necho 'test_execution_successful'",
@@ -668,8 +668,8 @@ func Test_when_executing_safe_bash_script_should_run_successfully(t *testing.T) 
 	// Assert
 	if err != nil {
 		// On Windows, bash might not be available or have path issues - that's expected
-		if runtime.GOOS == "windows" && (strings.Contains(err.Error(), "bash not found") || 
-			strings.Contains(err.Error(), "No such file") || 
+		if runtime.GOOS == "windows" && (strings.Contains(err.Error(), "bash not found") ||
+			strings.Contains(err.Error(), "No such file") ||
 			strings.Contains(err.Error(), "exit status 127")) {
 			t.Logf("Expected Windows bash error (bash unavailable or path issues): %v", err)
 			return
@@ -678,7 +678,7 @@ func Test_when_executing_safe_bash_script_should_run_successfully(t *testing.T) 
 	}
 }
 
-func Test_when_executing_safe_powershell_script_should_run_successfully(t *testing.T) {
+func Test_when_executing_safe_powershell_script_then_run_successfully(t *testing.T) {
 	// Skip on non-Windows systems where PowerShell might not be available
 	if runtime.GOOS != "windows" {
 		t.Skip("Skipping PowerShell test on non-Windows system")
@@ -703,7 +703,7 @@ func Test_when_executing_safe_powershell_script_should_run_successfully(t *testi
 	}
 }
 
-func Test_when_executing_script_with_invalid_syntax_should_return_error(t *testing.T) {
+func Test_when_executing_script_with_invalid_syntax_then_return_error(t *testing.T) {
 	// Arrange - Create a script with invalid syntax
 	response := &types.ScriptResponse{
 		Script:          "this is not valid bash syntax {{{{ ]]]]",
@@ -722,15 +722,15 @@ func Test_when_executing_script_with_invalid_syntax_should_return_error(t *testi
 	}
 }
 
-func Test_when_executing_script_should_create_and_cleanup_temp_file(t *testing.T) {
+func Test_when_executing_script_then_create_and_cleanup_temp_file(t *testing.T) {
 	// This test verifies that temporary files are created and cleaned up properly
 	// We can't easily test the cleanup directly since it happens in defer,
 	// but we can test that the function doesn't leave temp files around
-	
+
 	// Arrange
 	response := &types.ScriptResponse{
 		Script:          "echo 'temp file test'",
-		ScriptType:      "bash", 
+		ScriptType:      "bash",
 		TaskDescription: "test temp file handling",
 		Provider:        "test",
 		Model:           "test-model",
@@ -769,9 +769,9 @@ func Test_when_executing_script_should_create_and_cleanup_temp_file(t *testing.T
 	}
 }
 
-func Test_when_executing_powershell_script_on_windows_should_use_correct_command(t *testing.T) {
+func Test_when_executing_powershell_script_on_windows_then_use_correct_command(t *testing.T) {
 	// This test verifies PowerShell execution path without actually running dangerous commands
-	
+
 	// Skip on non-Windows systems
 	if runtime.GOOS != "windows" {
 		t.Skip("Skipping Windows-specific PowerShell test")
@@ -783,7 +783,7 @@ func Test_when_executing_powershell_script_on_windows_should_use_correct_command
 		Script:          "$null", // This does nothing but is valid PowerShell
 		ScriptType:      "powershell",
 		TaskDescription: "test powershell command path",
-		Provider:        "test", 
+		Provider:        "test",
 		Model:           "test-model",
 	}
 
@@ -796,7 +796,7 @@ func Test_when_executing_powershell_script_on_windows_should_use_correct_command
 	}
 }
 
-func Test_when_executing_bash_script_on_windows_without_bash_should_return_helpful_error(t *testing.T) {
+func Test_when_executing_bash_script_on_windows_without_bash_then_return_helpful_error(t *testing.T) {
 	// Skip if not on Windows
 	if runtime.GOOS != "windows" {
 		t.Skip("Skipping Windows-specific bash error test")
@@ -833,7 +833,7 @@ func Test_when_executing_bash_script_on_windows_without_bash_should_return_helpf
 	}
 }
 
-func Test_when_executing_script_with_empty_content_should_handle_gracefully(t *testing.T) {
+func Test_when_executing_script_with_empty_content_then_handle_gracefully(t *testing.T) {
 	// Arrange
 	response := &types.ScriptResponse{
 		Script:          "",
@@ -853,11 +853,11 @@ func Test_when_executing_script_with_empty_content_should_handle_gracefully(t *t
 	}
 }
 
-func Test_when_executing_script_should_handle_file_creation_errors_gracefully(t *testing.T) {
+func Test_when_executing_script_then_handle_file_creation_errors_gracefully(t *testing.T) {
 	// This test would require creating a scenario where temp file creation fails
 	// Since we can't easily simulate filesystem errors in a unit test,
 	// we'll test with an edge case that might cause issues
-	
+
 	// Arrange - Script with potentially problematic characters
 	response := &types.ScriptResponse{
 		Script:          "echo 'test with unicode: 你好 🌟'",

--- a/script/refinement_test.go
+++ b/script/refinement_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 // TestRefineScript_WithUserInput tests script refinement with user feedback
-func TestRefineScript_WithUserInput(t *testing.T) {
+func Test_when_refine_script_then_with_user_input(t *testing.T) {
 	// Mock provider for testing
 	mockProvider := &MockProvider{
 		GenerateScriptFunc: func(req *types.ScriptRequest) (*types.ScriptResponse, error) {
@@ -17,16 +17,16 @@ func TestRefineScript_WithUserInput(t *testing.T) {
 				return &types.ScriptResponse{
 					Script:          "echo 'Fast version'",
 					Provider:        req.Provider,
-					Model:          req.Model,
-					ScriptType:     req.ScriptType,
+					Model:           req.Model,
+					ScriptType:      req.ScriptType,
 					TaskDescription: req.TaskDescription,
 				}, nil
 			}
 			return &types.ScriptResponse{
 				Script:          "echo 'Original version'",
 				Provider:        req.Provider,
-				Model:          req.Model,
-				ScriptType:     req.ScriptType,
+				Model:           req.Model,
+				ScriptType:      req.ScriptType,
 				TaskDescription: req.TaskDescription,
 			}, nil
 		},
@@ -35,8 +35,8 @@ func TestRefineScript_WithUserInput(t *testing.T) {
 	originalResponse := &types.ScriptResponse{
 		Script:          "echo 'Original script'",
 		Provider:        "ollama",
-		Model:          "llama3.2",
-		ScriptType:     "bash",
+		Model:           "llama3.2",
+		ScriptType:      "bash",
 		TaskDescription: "create echo script",
 	}
 
@@ -70,7 +70,7 @@ func TestRefineScript_WithUserInput(t *testing.T) {
 }
 
 // TestRefineScript_ProperPrompt tests that refinement creates appropriate prompts
-func TestRefineScript_ProperPrompt(t *testing.T) {
+func Test_when_refine_script_then_proper_prompt(t *testing.T) {
 	var receivedRequest *types.ScriptRequest
 
 	mockProvider := &MockProvider{
@@ -79,8 +79,8 @@ func TestRefineScript_ProperPrompt(t *testing.T) {
 			return &types.ScriptResponse{
 				Script:          "echo 'Refined script'",
 				Provider:        req.Provider,
-				Model:          req.Model,
-				ScriptType:     req.ScriptType,
+				Model:           req.Model,
+				ScriptType:      req.ScriptType,
 				TaskDescription: req.TaskDescription,
 			}, nil
 		},
@@ -89,8 +89,8 @@ func TestRefineScript_ProperPrompt(t *testing.T) {
 	originalResponse := &types.ScriptResponse{
 		Script:          "echo 'Original script'",
 		Provider:        "ollama",
-		Model:          "llama3.2",
-		ScriptType:     "bash",
+		Model:           "llama3.2",
+		ScriptType:      "bash",
 		TaskDescription: "create echo script",
 	}
 

--- a/script/test_monitor_test.go
+++ b/script/test_monitor_test.go
@@ -7,9 +7,9 @@ import (
 )
 
 // TestParseTestFailures tests the test failure parsing functionality
-func TestParseTestFailures(t *testing.T) {
+func Test_when_parsing_test_failures_then_extract_results(t *testing.T) {
 	tm := &TestMonitor{}
-	
+
 	// Sample Go test output with failures
 	testOutput := `=== RUN   TestExample
 === RUN   TestExample/should_pass
@@ -23,46 +23,46 @@ func TestParseTestFailures(t *testing.T) {
 FAIL	example/package	0.012s`
 
 	failures := tm.parseTestFailures(testOutput, "go test -v")
-	
+
 	if len(failures) != 2 {
 		t.Errorf("Expected 2 failures, got %d", len(failures))
 	}
-	
+
 	// Check first failure
 	if failures[0].TestName != "TestExample/should_fail" {
 		t.Errorf("Expected test name 'TestExample/should_fail', got '%s'", failures[0].TestName)
 	}
-	
+
 	if failures[0].SourceFile != "example_test.go" {
 		t.Errorf("Expected source file 'example_test.go', got '%s'", failures[0].SourceFile)
 	}
-	
+
 	if failures[0].LineNumber != 15 {
 		t.Errorf("Expected line number 15, got %d", failures[0].LineNumber)
 	}
-	
+
 	if !strings.Contains(failures[0].ErrorMessage, "Expected 5, got 3") {
 		t.Errorf("Expected error message to contain 'Expected 5, got 3', got '%s'", failures[0].ErrorMessage)
 	}
-	
+
 	// Check second failure
 	if failures[1].TestName != "TestAnother" {
 		t.Errorf("Expected test name 'TestAnother', got '%s'", failures[1].TestName)
 	}
-	
+
 	if failures[1].SourceFile != "another_test.go" {
 		t.Errorf("Expected source file 'another_test.go', got '%s'", failures[1].SourceFile)
 	}
-	
+
 	if failures[1].LineNumber != 25 {
 		t.Errorf("Expected line number 25, got %d", failures[1].LineNumber)
 	}
 }
 
 // TestExtractLineNumber tests line number extraction
-func TestExtractLineNumber(t *testing.T) {
+func Test_when_extracting_line_number_then_return_correct_value(t *testing.T) {
 	tm := &TestMonitor{}
-	
+
 	tests := []struct {
 		location string
 		expected int
@@ -74,7 +74,7 @@ func TestExtractLineNumber(t *testing.T) {
 		{"test.go", 0},
 		{"", 0},
 	}
-	
+
 	for _, test := range tests {
 		result := tm.extractLineNumber(test.location)
 		if result != test.expected {
@@ -84,9 +84,9 @@ func TestExtractLineNumber(t *testing.T) {
 }
 
 // TestExtractFilePath tests file path extraction
-func TestExtractFilePath(t *testing.T) {
+func Test_when_extracting_file_path_then_return_correct_value(t *testing.T) {
 	tm := &TestMonitor{}
-	
+
 	tests := []struct {
 		location string
 		expected string
@@ -97,7 +97,7 @@ func TestExtractFilePath(t *testing.T) {
 		{"test.go", "test.go"},
 		{"", ""},
 	}
-	
+
 	for _, test := range tests {
 		result := tm.extractFilePath(test.location)
 		if result != test.expected {
@@ -107,53 +107,53 @@ func TestExtractFilePath(t *testing.T) {
 }
 
 // TestTruncateOutput tests output truncation
-func TestTruncateOutput(t *testing.T) {
+func Test_when_truncating_output_then_limit_length(t *testing.T) {
 	tm := &TestMonitor{}
-	
+
 	// Test short text (no truncation)
 	shortText := "This is a short text"
 	result := tm.truncateOutput(shortText, 100)
 	if result != shortText {
 		t.Errorf("Short text should not be truncated")
 	}
-	
+
 	// Test long text (should be truncated)
 	longText := strings.Repeat("a", 200)
 	result = tm.truncateOutput(longText, 50)
 	if len(result) > 65 { // 50 + "... (truncated)" length
 		t.Errorf("Long text should be truncated")
 	}
-	
+
 	if !strings.Contains(result, "... (truncated)") {
 		t.Errorf("Truncated text should contain truncation marker")
 	}
 }
 
 // TestNewTestMonitor tests monitor creation
-func TestNewTestMonitor(t *testing.T) {
+func Test_when_creating_new_test_monitor_then_initialize(t *testing.T) {
 	monitor := NewTestMonitor(nil, nil)
-	
+
 	if monitor == nil {
 		t.Error("NewTestMonitor should not return nil")
 	}
-	
+
 	if !monitor.VerboseMode {
 		t.Error("VerboseMode should be true by default")
 	}
-	
+
 	if !monitor.AutoAnalyze {
 		t.Error("AutoAnalyze should be true by default")
 	}
-	
+
 	if !monitor.SaveFailures {
 		t.Error("SaveFailures should be true by default")
 	}
 }
 
 // TestParseAIAnalysis tests AI response parsing
-func TestParseAIAnalysis(t *testing.T) {
+func Test_when_parsing_ai_analysis_then_extract_summary(t *testing.T) {
 	tm := &TestMonitor{}
-	
+
 	// Test valid JSON response
 	validJSON := `Some text before JSON {
 		"summary": "Test summary",
@@ -162,46 +162,46 @@ func TestParseAIAnalysis(t *testing.T) {
 		"requires_manual": false,
 		"failure_category": "logic_error"
 	} some text after`
-	
+
 	analysis := tm.parseAIAnalysis(validJSON)
-	
+
 	if analysis.Summary != "Test summary" {
 		t.Errorf("Expected summary 'Test summary', got '%s'", analysis.Summary)
 	}
-	
+
 	if analysis.RootCause != "Test root cause" {
 		t.Errorf("Expected root cause 'Test root cause', got '%s'", analysis.RootCause)
 	}
-	
+
 	if len(analysis.Suggestions) != 2 {
 		t.Errorf("Expected 2 suggestions, got %d", len(analysis.Suggestions))
 	}
-	
+
 	if analysis.RequiresManual {
 		t.Error("RequiresManual should be false")
 	}
-	
+
 	if analysis.FailureCategory != "logic_error" {
 		t.Errorf("Expected failure category 'logic_error', got '%s'", analysis.FailureCategory)
 	}
-	
+
 	// Test invalid JSON response (should return fallback)
 	invalidJSON := "This is not JSON at all"
 	analysis = tm.parseAIAnalysis(invalidJSON)
-	
+
 	if analysis.Summary != "AI analysis parsing failed" {
 		t.Errorf("Expected fallback summary for invalid JSON")
 	}
-	
+
 	if !analysis.RequiresManual {
 		t.Error("RequiresManual should be true for fallback analysis")
 	}
 }
 
 // TestBuildAnalysisPrompt tests the AI prompt generation
-func TestBuildAnalysisPrompt(t *testing.T) {
+func Test_when_building_analysis_prompt_then_include_context(t *testing.T) {
 	tm := &TestMonitor{}
-	
+
 	failure := TestFailure{
 		TestName:     "TestExample",
 		PackageName:  "example",
@@ -210,29 +210,29 @@ func TestBuildAnalysisPrompt(t *testing.T) {
 		ErrorMessage: "Expected 5, got 3",
 		Timestamp:    time.Date(2023, 1, 1, 12, 0, 0, 0, time.UTC),
 	}
-	
+
 	prompt := tm.buildAnalysisPrompt(failure, "test output", "source code")
-	
+
 	if !strings.Contains(prompt, "TestExample") {
 		t.Error("Prompt should contain test name")
 	}
-	
+
 	if !strings.Contains(prompt, "example") {
 		t.Error("Prompt should contain package name")
 	}
-	
+
 	if !strings.Contains(prompt, "test.go") {
 		t.Error("Prompt should contain source file")
 	}
-	
+
 	if !strings.Contains(prompt, "Expected 5, got 3") {
 		t.Error("Prompt should contain error message")
 	}
-	
+
 	if !strings.Contains(prompt, "JSON response") {
 		t.Error("Prompt should request JSON response")
 	}
-	
+
 	if !strings.Contains(prompt, "root_cause") {
 		t.Error("Prompt should specify required JSON fields")
 	}

--- a/script/validation_test.go
+++ b/script/validation_test.go
@@ -9,12 +9,12 @@ import (
 
 func TestValidateScript(t *testing.T) {
 	tests := []struct {
-		name           string
-		script         string
-		scriptType     string
-		expectedCount  int
-		expectedLevel  string // "critical", "warning", "caution", "info", "none"
-		description    string
+		name          string
+		script        string
+		scriptType    string
+		expectedCount int
+		expectedLevel string // "critical", "warning", "caution", "info", "none"
+		description   string
 	}{
 		{
 			name:          "PowerShell Date Format - Should NOT Warn",
@@ -81,7 +81,7 @@ func TestValidateScript(t *testing.T) {
 			description:   "String containing 'format' should not trigger warning",
 		},
 		{
-			name:          "Safe - Complex PowerShell",
+			name: "Safe - Complex PowerShell",
 			script: `try {
     $currentTime = Get-Date -Format "yyyy-MM-dd HH:mm:ss"
     $computerName = $env:COMPUTERNAME
@@ -112,10 +112,10 @@ func TestValidateScript(t *testing.T) {
 			}
 
 			warnings := ValidateScript(response)
-			
+
 			// Check warning count
 			if len(warnings) != tt.expectedCount {
-				t.Errorf("Expected %d warnings, got %d for script: %s\nWarnings: %v", 
+				t.Errorf("Expected %d warnings, got %d for script: %s\nWarnings: %v",
 					tt.expectedCount, len(warnings), tt.script, warnings)
 			}
 
@@ -193,7 +193,7 @@ func TestContainsCommand(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			result := containsCommand(strings.ToLower(tt.script), tt.pattern)
 			if result != tt.expected {
-				t.Errorf("containsCommand(%q, %q) = %v, expected %v: %s", 
+				t.Errorf("containsCommand(%q, %q) = %v, expected %v: %s",
 					tt.script, tt.pattern, result, tt.expected, tt.reason)
 			}
 		})

--- a/types/types_test.go
+++ b/types/types_test.go
@@ -13,19 +13,19 @@ func TestConfig(t *testing.T) {
 		ModelOverrides:  make(map[string]string),
 		CustomProviders: make(map[string]ProviderConfig),
 	}
-	
+
 	if cfg.Provider != "ollama" {
 		t.Errorf("Expected provider 'ollama', got '%s'", cfg.Provider)
 	}
-	
+
 	if cfg.PreferredModel != "llama3.2" {
 		t.Errorf("Expected model 'llama3.2', got '%s'", cfg.PreferredModel)
 	}
-	
+
 	if cfg.ModelOverrides == nil {
 		t.Error("ModelOverrides should be initialized")
 	}
-	
+
 	if cfg.CustomProviders == nil {
 		t.Error("CustomProviders should be initialized")
 	}
@@ -38,15 +38,15 @@ func TestProviderConfig(t *testing.T) {
 		Model:   "test-model",
 		Headers: map[string]string{"Authorization": "Bearer test"},
 	}
-	
+
 	if providerCfg.URL != "http://localhost:11434" {
 		t.Errorf("Expected URL 'http://localhost:11434', got '%s'", providerCfg.URL)
 	}
-	
+
 	if providerCfg.APIKey != "test-key" {
 		t.Errorf("Expected API key 'test-key', got '%s'", providerCfg.APIKey)
 	}
-	
+
 	if providerCfg.Headers["Authorization"] != "Bearer test" {
 		t.Error("Headers should contain Authorization")
 	}
@@ -60,15 +60,15 @@ func TestModelInfo(t *testing.T) {
 		Size:       1024,
 		Digest:     "abc123",
 	}
-	
+
 	if modelInfo.Name != "llama3.2" {
 		t.Errorf("Expected name 'llama3.2', got '%s'", modelInfo.Name)
 	}
-	
+
 	if modelInfo.Size != 1024 {
 		t.Errorf("Expected size 1024, got %d", modelInfo.Size)
 	}
-	
+
 	if modelInfo.ModifiedAt != now {
 		t.Error("ModifiedAt should match the set time")
 	}
@@ -81,15 +81,15 @@ func TestScriptRequest(t *testing.T) {
 		Provider:        "ollama",
 		Model:           "llama3.2",
 	}
-	
+
 	if request.TaskDescription != "Create a backup script" {
 		t.Errorf("Expected task description 'Create a backup script', got '%s'", request.TaskDescription)
 	}
-	
+
 	if request.ScriptType != "powershell" {
 		t.Errorf("Expected script type 'powershell', got '%s'", request.ScriptType)
 	}
-	
+
 	if request.Provider != "ollama" {
 		t.Errorf("Expected provider 'ollama', got '%s'", request.Provider)
 	}
@@ -103,11 +103,11 @@ func TestScriptResponse(t *testing.T) {
 		TaskDescription: "Show current date",
 		ScriptType:      "powershell",
 	}
-	
+
 	if response.Script != "Get-Date" {
 		t.Errorf("Expected script 'Get-Date', got '%s'", response.Script)
 	}
-	
+
 	if response.TaskDescription != "Show current date" {
 		t.Errorf("Expected task description 'Show current date', got '%s'", response.TaskDescription)
 	}
@@ -118,11 +118,11 @@ func TestMessage(t *testing.T) {
 		Role:    "user",
 		Content: "Hello, how are you?",
 	}
-	
+
 	if message.Role != "user" {
 		t.Errorf("Expected role 'user', got '%s'", message.Role)
 	}
-	
+
 	if message.Content != "Hello, how are you?" {
 		t.Errorf("Expected content 'Hello, how are you?', got '%s'", message.Content)
 	}
@@ -135,15 +135,15 @@ func TestOpenAIRequest(t *testing.T) {
 		Temperature: 0.7,
 		MaxTokens:   1000,
 	}
-	
+
 	if request.Model != "gpt-4" {
 		t.Errorf("Expected model 'gpt-4', got '%s'", request.Model)
 	}
-	
+
 	if len(request.Messages) != 1 {
 		t.Errorf("Expected 1 message, got %d", len(request.Messages))
 	}
-	
+
 	if request.Temperature != 0.7 {
 		t.Errorf("Expected temperature 0.7, got %f", request.Temperature)
 	}
@@ -156,15 +156,15 @@ func TestOllamaRequest(t *testing.T) {
 		Stream:  false,
 		Options: make(map[string]interface{}),
 	}
-	
+
 	if request.Model != "llama3.2" {
 		t.Errorf("Expected model 'llama3.2', got '%s'", request.Model)
 	}
-	
+
 	if request.Prompt != "Hello world" {
 		t.Errorf("Expected prompt 'Hello world', got '%s'", request.Prompt)
 	}
-	
+
 	if request.Stream != false {
 		t.Error("Expected stream to be false")
 	}

--- a/ui/banner_test.go
+++ b/ui/banner_test.go
@@ -11,7 +11,7 @@ import (
 
 // Test banner functions for business logic only (no cosmetic testing)
 
-func TestWhenBannerWithZeroDelay_ShouldCompleteImmediately(t *testing.T) {
+func Test_when_banner_with_zero_delay_then_complete_immediately(t *testing.T) {
 	// Arrange
 	start := time.Now()
 
@@ -25,7 +25,7 @@ func TestWhenBannerWithZeroDelay_ShouldCompleteImmediately(t *testing.T) {
 	}
 }
 
-func TestWhenBannerWithDelay_ShouldRespectTiming(t *testing.T) {
+func Test_when_banner_with_delay_then_respect_timing(t *testing.T) {
 	// Arrange
 	testDelay := 5 * time.Millisecond
 	start := time.Now()
@@ -61,7 +61,7 @@ func captureStdout(fn func()) string {
 	return out
 }
 
-func TestWhenPrintingRainbowBannerWithZeroDelay_ShouldPrintAsciiArt(t *testing.T) {
+func Test_when_printing_rainbow_banner_with_zero_delay_then_print_ascii_art(t *testing.T) {
 	output := captureStdout(func() { PrintRainbowBannerWithDelay(0) })
 	if !strings.Contains(output, "██████╗") {
 		t.Errorf("Expected banner to include ASCII art, got: %s", output)
@@ -72,7 +72,7 @@ func TestWhenPrintingRainbowBannerWithZeroDelay_ShouldPrintAsciiArt(t *testing.T
 	}
 }
 
-func TestWhenCallingPrintInstallationSuccess_ShouldShowMagicMessage(t *testing.T) {
+func Test_when_calling_print_installation_success_then_show_magic_message(t *testing.T) {
 	output := captureStdout(PrintInstallationSuccess)
 	if !strings.Contains(output, "Installation complete") {
 		t.Errorf("Expected installation message, got: %s", output)
@@ -82,7 +82,7 @@ func TestWhenCallingPrintInstallationSuccess_ShouldShowMagicMessage(t *testing.T
 	}
 }
 
-func TestWhenCallingPrintFooter_ShouldDisplayHelpfulTips(t *testing.T) {
+func Test_when_calling_print_footer_then_display_helpful_tips(t *testing.T) {
 	output := captureStdout(PrintFooter)
 	if !strings.Contains(output, "Happy scripting") {
 		t.Errorf("Expected footer tips, got: %s", output)
@@ -92,7 +92,7 @@ func TestWhenCallingPrintFooter_ShouldDisplayHelpfulTips(t *testing.T) {
 	}
 }
 
-func TestWhenCallingPrintRainbowBanner_ShouldUseDefaultDelay(t *testing.T) {
+func Test_when_calling_print_rainbow_banner_then_use_default_delay(t *testing.T) {
 	start := time.Now()
 	PrintRainbowBanner()
 	if time.Since(start) < 50*time.Millisecond {

--- a/ui/colors_test.go
+++ b/ui/colors_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 // TestWhenCheckingColorConstants_ShouldProvideEscapeCodes verifies color constants are escape sequences
-func TestWhenCheckingColorConstants_ShouldProvideEscapeCodes(t *testing.T) {
+func Test_when_checking_color_constants_then_provide_escape_codes(t *testing.T) {
 	colors := []string{ColorReset, ColorRed, ColorGreen, ColorYellow, ColorBlue, ColorPurple, ColorMagenta, ColorCyan, ColorWhite, ColorBold, ColorDim,
 		BgRed, BgGreen, BgYellow, BgBlue, BgPurple, BgCyan,
 		Rainbow1, Rainbow2, Rainbow3, Rainbow4, Rainbow5, Rainbow6, Rainbow7}
@@ -18,14 +18,14 @@ func TestWhenCheckingColorConstants_ShouldProvideEscapeCodes(t *testing.T) {
 }
 
 // TestWhenCheckingColorAliases_ShouldMatch ensures magenta equals purple
-func TestWhenCheckingColorAliases_ShouldMatch(t *testing.T) {
+func Test_when_checking_color_aliases_then_match(t *testing.T) {
 	if ColorMagenta != ColorPurple {
 		t.Errorf("expected ColorMagenta to equal ColorPurple")
 	}
 }
 
 // TestWhenCheckingRainbowColors_ShouldBeUnique verifies rainbow colors are unique
-func TestWhenCheckingRainbowColors_ShouldBeUnique(t *testing.T) {
+func Test_when_checking_rainbow_colors_then_be_unique(t *testing.T) {
 	colors := []string{Rainbow1, Rainbow2, Rainbow3, Rainbow4, Rainbow5, Rainbow6, Rainbow7}
 	seen := make(map[string]bool)
 	for _, c := range colors {

--- a/ui/help_test.go
+++ b/ui/help_test.go
@@ -25,7 +25,7 @@ func captureStdoutForHelp(fn func()) string {
 	return <-outC
 }
 
-func TestWhenShowingHelp_ShouldDisplayUsageExamples(t *testing.T) {
+func Test_when_showing_help_then_display_usage_examples(t *testing.T) {
 	output := captureStdoutForHelp(ShowHelp)
 	if !strings.Contains(output, "Natural Language Usage") {
 		t.Errorf("expected help to mention usage, got: %s", output)
@@ -35,7 +35,7 @@ func TestWhenShowingHelp_ShouldDisplayUsageExamples(t *testing.T) {
 	}
 }
 
-func TestWhenShowingVersion_ShouldDisplayVersionInfo(t *testing.T) {
+func Test_when_showing_version_then_display_version_info(t *testing.T) {
 	output := captureStdoutForHelp(ShowVersion)
 	if !strings.Contains(output, "Please v5.0.0") {
 		t.Errorf("expected version output, got: %s", output)
@@ -45,7 +45,7 @@ func TestWhenShowingVersion_ShouldDisplayVersionInfo(t *testing.T) {
 	}
 }
 
-func TestWhenUsingInjectedBanner_ShouldInvokeBannerFunction(t *testing.T) {
+func Test_when_using_injected_banner_then_invoke_banner_function(t *testing.T) {
 	called := false
 	showHelpWithBanner(func() { called = true })
 	if !called {
@@ -53,7 +53,7 @@ func TestWhenUsingInjectedBanner_ShouldInvokeBannerFunction(t *testing.T) {
 	}
 }
 
-func TestWhenShowingVersion_ShouldIncludeRuntimeDetails(t *testing.T) {
+func Test_when_showing_version_then_include_runtime_details(t *testing.T) {
 	output := captureStdoutForHelp(ShowVersion)
 	if !strings.Contains(output, runtime.GOOS) {
 		t.Errorf("expected GOOS %s in output", runtime.GOOS)

--- a/ui/interactive_actions_test.go
+++ b/ui/interactive_actions_test.go
@@ -1,0 +1,198 @@
+package ui
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"please/types"
+)
+
+// Test saveLastScript and loadLastScriptData functions
+func Test_when_saving_and_loading_last_script_then_preserve_data(t *testing.T) {
+	// Arrange - create temporary directory for testing
+	tempDir := t.TempDir()
+
+	// Mock the getConfigDir function behavior by setting up the file in temp dir
+	response := &types.ScriptResponse{
+		TaskDescription: "test task",
+		Script:          "echo 'hello world'",
+		ScriptType:      "bash",
+		Model:           "test-model",
+		Provider:        "test-provider",
+	}
+
+	// Save the script to temp directory directly
+	lastScriptPath := filepath.Join(tempDir, "last_script.json")
+	jsonContent := `{
+  "task_description": "test task",
+  "script": "echo 'hello world'",
+  "script_type": "bash",
+  "model": "test-model",
+  "provider": "test-provider"
+}`
+	err := os.WriteFile(lastScriptPath, []byte(jsonContent), 0644)
+	if err != nil {
+		t.Fatalf("Failed to write test file: %v", err)
+	}
+
+	// Act - read and parse the saved data
+	data, err := os.ReadFile(lastScriptPath)
+	if err != nil {
+		t.Fatalf("Failed to read test file: %v", err)
+	}
+
+	content := string(data)
+	taskDesc := extractJSONField(content, "task_description")
+	script := extractJSONField(content, "script")
+	scriptType := extractJSONField(content, "script_type")
+	model := extractJSONField(content, "model")
+	provider := extractJSONField(content, "provider")
+
+	// Assert
+	if taskDesc != response.TaskDescription {
+		t.Errorf("Expected task description '%s', got '%s'", response.TaskDescription, taskDesc)
+	}
+	if script != response.Script {
+		t.Errorf("Expected script '%s', got '%s'", response.Script, script)
+	}
+	if scriptType != response.ScriptType {
+		t.Errorf("Expected script type '%s', got '%s'", response.ScriptType, scriptType)
+	}
+	if model != response.Model {
+		t.Errorf("Expected model '%s', got '%s'", response.Model, model)
+	}
+	if provider != response.Provider {
+		t.Errorf("Expected provider '%s', got '%s'", response.Provider, provider)
+	}
+}
+
+func Test_when_loading_nonexistent_last_script_then_return_nil(t *testing.T) {
+	// Act
+	result := loadLastScriptData()
+
+	// Assert - should return nil for nonexistent file
+	// Note: This test depends on the actual implementation,
+	// but verifies the function handles missing files gracefully
+	if result != nil {
+		// If it returns something, verify it's a valid response structure
+		if result.TaskDescription == "" && result.Script == "" {
+			// This is acceptable - function may return empty struct instead of nil
+		}
+	}
+}
+
+// Test file handling with escaped content
+func Test_when_script_contains_special_characters_then_handle_escaping(t *testing.T) {
+	// Arrange
+	content := `{
+  "task_description": "create \"complex\" script with \\ backslashes",
+  "script": "echo \"hello \\\"world\\\"\"",
+  "script_type": "bash"
+}`
+
+	// Act
+	taskDesc := extractJSONField(content, "task_description")
+	script := extractJSONField(content, "script")
+
+	// Assert
+	expectedTask := `create "complex" script with \ backslashes`
+	expectedScript := `echo "hello \"world\""`
+
+	if taskDesc != expectedTask {
+		t.Errorf("Expected task description '%s', got '%s'", expectedTask, taskDesc)
+	}
+	if script != expectedScript {
+		t.Errorf("Expected script '%s', got '%s'", expectedScript, script)
+	}
+}
+
+// Test renderMenu behavior with input injection
+func Test_when_renderMenu_with_injected_input_then_handle_choice(t *testing.T) {
+	// Arrange
+	callCount := 0
+	items := []MenuItem{
+		{Label: "Test Option", Icon: "🧪", Color: ColorGreen, Action: func() bool {
+			callCount++
+			return true // Exit after first call
+		}},
+	}
+
+	// Mock input function that returns '1' (first option)
+	mockInput := func() rune {
+		return '1'
+	}
+
+	// Act
+	renderMenu("Test Menu", "Choose: ", items, mockInput)
+
+	// Assert
+	if callCount != 1 {
+		t.Errorf("Expected action to be called once, called %d times", callCount)
+	}
+}
+
+func Test_when_renderMenu_with_enter_input_then_exit_immediately(t *testing.T) {
+	// Arrange
+	callCount := 0
+	items := []MenuItem{
+		{Label: "Test Option", Icon: "🧪", Color: ColorGreen, Action: func() bool {
+			callCount++
+			return false
+		}},
+	}
+
+	// Mock input function that returns Enter
+	mockInput := func() rune {
+		return '\r'
+	}
+
+	// Act
+	renderMenu("Test Menu", "Choose: ", items, mockInput)
+
+	// Assert
+	if callCount != 0 {
+		t.Errorf("Expected no action calls for Enter key, called %d times", callCount)
+	}
+}
+
+func Test_when_renderMenu_with_invalid_choice_then_continue_loop(t *testing.T) {
+	// Arrange
+	callCount := 0
+	items := []MenuItem{
+		{Label: "Test Option", Icon: "🧪", Color: ColorGreen, Action: func() bool {
+			callCount++
+			return true // Exit when called
+		}},
+	}
+
+	inputSequence := []rune{'9', '1'} // Invalid choice, then valid choice
+	inputIndex := 0
+
+	mockInput := func() rune {
+		result := inputSequence[inputIndex]
+		inputIndex++
+		return result
+	}
+
+	// Act
+	renderMenu("Test Menu", "Choose: ", items, mockInput)
+
+	// Assert
+	if callCount != 1 {
+		t.Errorf("Expected action to be called once after invalid choice, called %d times", callCount)
+	}
+}
+
+// Helper function to capture output for testing
+func captureOutput(fn func()) string {
+	r, w, _ := os.Pipe()
+	old := os.Stdout
+	os.Stdout = w
+	fn()
+	w.Close()
+	os.Stdout = old
+	data, _ := io.ReadAll(r)
+	return string(data)
+}

--- a/ui/interactive_config_test.go
+++ b/ui/interactive_config_test.go
@@ -1,0 +1,54 @@
+package ui
+
+import (
+	"os"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// Test getConfigDir function
+func Test_when_getting_config_dir_then_return_platform_specific_path(t *testing.T) {
+	// Act
+	configDir, err := getConfigDir()
+
+	// Assert
+	if err != nil {
+		t.Errorf("Expected no error, got: %v", err)
+	}
+
+	if configDir == "" {
+		t.Error("Expected non-empty config directory path")
+	}
+
+	// Verify platform-specific path format
+	switch runtime.GOOS {
+	case "windows":
+		if !strings.Contains(configDir, "please") {
+			t.Errorf("Expected Windows config dir to contain 'please', got: %s", configDir)
+		}
+	case "darwin":
+		if !strings.Contains(configDir, "Library/Application Support") {
+			t.Errorf("Expected macOS config dir to contain 'Library/Application Support', got: %s", configDir)
+		}
+	default: // Linux and others
+		if !strings.Contains(configDir, ".config") {
+			t.Errorf("Expected Linux config dir to contain '.config', got: %s", configDir)
+		}
+	}
+}
+
+func Test_when_getting_config_dir_then_create_directory_if_not_exists(t *testing.T) {
+	// Act
+	configDir, err := getConfigDir()
+
+	// Assert
+	if err != nil {
+		t.Errorf("Expected no error, got: %v", err)
+	}
+
+	// Verify directory was created
+	if _, statErr := os.Stat(configDir); os.IsNotExist(statErr) {
+		t.Errorf("Expected config directory to be created at: %s", configDir)
+	}
+}

--- a/ui/interactive_extract_test.go
+++ b/ui/interactive_extract_test.go
@@ -1,0 +1,105 @@
+package ui
+
+import "testing"
+
+func Test_when_extracting_valid_field_then_return_correct_value(t *testing.T) {
+	// Arrange
+	content := `{
+  "task_description": "list all files",
+  "script": "ls -la",
+  "script_type": "bash"
+}`
+	field := "task_description"
+	expected := "list all files"
+
+	// Act
+	result := extractJSONField(content, field)
+
+	// Assert
+	if result != expected {
+		t.Errorf("Expected '%s', got '%s'", expected, result)
+	}
+}
+
+func Test_when_extracting_script_field_then_return_correct_value(t *testing.T) {
+	// Arrange
+	content := `{
+  "task_description": "create backup",
+  "script": "cp /home/user /backup",
+  "script_type": "bash"
+}`
+	field := "script"
+	expected := "cp /home/user /backup"
+
+	// Act
+	result := extractJSONField(content, field)
+
+	// Assert
+	if result != expected {
+		t.Errorf("Expected '%s', got '%s'", expected, result)
+	}
+}
+
+func Test_when_extracting_nonexistent_field_then_return_empty_string(t *testing.T) {
+	// Arrange
+	content := `{
+  "task_description": "list all files",
+  "script": "ls -la"
+}`
+	field := "nonexistent_field"
+
+	// Act
+	result := extractJSONField(content, field)
+
+	// Assert
+	if result != "" {
+		t.Errorf("Expected empty string for nonexistent field, got '%s'", result)
+	}
+}
+
+func Test_when_extracting_from_empty_content_then_return_empty_string(t *testing.T) {
+	// Arrange
+	content := ""
+	field := "task_description"
+
+	// Act
+	result := extractJSONField(content, field)
+
+	// Assert
+	if result != "" {
+		t.Errorf("Expected empty string for empty content, got '%s'", result)
+	}
+}
+
+func Test_when_extracting_field_with_escaped_quotes_then_return_unescaped_value(t *testing.T) {
+	// Arrange
+	content := `{
+  "task_description": "create a \"hello world\" script",
+  "script": "echo \"hello\""
+}`
+	field := "task_description"
+	expected := `create a "hello world" script`
+
+	// Act
+	result := extractJSONField(content, field)
+
+	// Assert
+	if result != expected {
+		t.Errorf("Expected '%s', got '%s'", expected, result)
+	}
+}
+
+func Test_when_extracting_field_with_malformed_json_then_return_empty_string(t *testing.T) {
+	// Arrange
+	content := `{
+  "task_description": "incomplete json field`
+	field := "task_description"
+
+	// Act
+	result := extractJSONField(content, field)
+
+	// Assert
+	if result != "" {
+		t.Errorf("Expected empty string for malformed JSON, got '%s'", result)
+	}
+}

--- a/ui/interactive_menu_test.go
+++ b/ui/interactive_menu_test.go
@@ -1,0 +1,95 @@
+package ui
+
+import "testing"
+
+// Test handleMainMenuChoice function
+func Test_when_choice_is_enter_then_return_true_for_exit(t *testing.T) {
+	// Arrange
+	choice := "\r"
+
+	// Act
+	result := handleMainMenuChoice(choice)
+
+	// Assert
+	if !result {
+		t.Error("Expected handleMainMenuChoice to return true for Enter key")
+	}
+}
+
+func Test_when_choice_is_newline_then_return_true_for_exit(t *testing.T) {
+	// Arrange
+	choice := "\n"
+
+	// Act
+	result := handleMainMenuChoice(choice)
+
+	// Assert
+	if !result {
+		t.Error("Expected handleMainMenuChoice to return true for newline")
+	}
+}
+
+func Test_when_choice_is_empty_then_return_false_to_continue(t *testing.T) {
+	// Arrange
+	choice := ""
+
+	// Act
+	result := handleMainMenuChoice(choice)
+
+	// Assert
+	if result {
+		t.Error("Expected handleMainMenuChoice to return false for empty choice")
+	}
+}
+
+func Test_when_choice_is_space_then_return_false_to_continue(t *testing.T) {
+	// Arrange
+	choice := " "
+
+	// Act
+	result := handleMainMenuChoice(choice)
+
+	// Assert
+	if result {
+		t.Error("Expected handleMainMenuChoice to return false for space")
+	}
+}
+
+func Test_when_choice_is_6_then_return_true_for_exit(t *testing.T) {
+	// Arrange
+	choice := "6"
+
+	// Act
+	result := handleMainMenuChoice(choice)
+
+	// Assert
+	if !result {
+		t.Error("Expected handleMainMenuChoice to return true for choice '6' (exit)")
+	}
+}
+
+func Test_when_choice_is_1_then_return_false_to_continue(t *testing.T) {
+	// Arrange
+	choice := "1"
+
+	// Act
+	result := handleMainMenuChoice(choice)
+
+	// Assert
+	if result {
+		t.Error("Expected handleMainMenuChoice to return false for choice '1' (help)")
+	}
+}
+
+func Test_when_choice_is_invalid_then_return_false_to_continue(t *testing.T) {
+	// Arrange
+	choice := "invalid"
+
+	// Act
+	result := handleMainMenuChoice(choice)
+
+	// Assert
+	if result {
+		t.Error("Expected handleMainMenuChoice to return false for invalid choice")
+	}
+}

--- a/ui/interactive_more_test.go
+++ b/ui/interactive_more_test.go
@@ -10,7 +10,7 @@ import (
 	"please/types"
 )
 
-func TestWhenSavingToHistory_ShouldWriteHistoryFile(t *testing.T) {
+func Test_when_saving_to_history_then_write_history_file(t *testing.T) {
 	temp := t.TempDir()
 	if runtime.GOOS == "windows" {
 		t.Setenv("APPDATA", temp)
@@ -39,7 +39,7 @@ func TestWhenSavingToHistory_ShouldWriteHistoryFile(t *testing.T) {
 	}
 }
 
-func TestWhenSavingLastScript_ShouldWriteFile(t *testing.T) {
+func Test_when_saving_last_script_then_write_file(t *testing.T) {
 	temp := t.TempDir()
 	if runtime.GOOS == "windows" {
 		t.Setenv("APPDATA", temp)
@@ -68,7 +68,7 @@ func TestWhenSavingLastScript_ShouldWriteFile(t *testing.T) {
 	}
 }
 
-func TestWhenLoadingLastScriptData_ShouldReturnValues(t *testing.T) {
+func Test_when_loading_last_script_data_then_return_values(t *testing.T) {
 	temp := t.TempDir()
 	if runtime.GOOS == "windows" {
 		t.Setenv("APPDATA", temp)
@@ -91,7 +91,7 @@ func TestWhenLoadingLastScriptData_ShouldReturnValues(t *testing.T) {
 	}
 }
 
-func TestWhenGetSingleKeyUnix_ShouldReturnRune(t *testing.T) {
+func Test_when_get_single_key_unix_then_return_rune(t *testing.T) {
 	tmp, _ := os.CreateTemp(t.TempDir(), "stdin")
 	tmp.WriteString("a\n")
 	tmp.Seek(0, 0)
@@ -104,7 +104,7 @@ func TestWhenGetSingleKeyUnix_ShouldReturnRune(t *testing.T) {
 	}
 }
 
-func TestWhenGetSingleKeyWindows_ShouldReturnRune(t *testing.T) {
+func Test_when_get_single_key_windows_then_return_rune(t *testing.T) {
 	tmp, _ := os.CreateTemp(t.TempDir(), "stdin")
 	tmp.WriteString("b\n")
 	tmp.Seek(0, 0)
@@ -117,7 +117,7 @@ func TestWhenGetSingleKeyWindows_ShouldReturnRune(t *testing.T) {
 	}
 }
 
-func TestWhenGetSingleKeyInput_ShouldReturnRune(t *testing.T) {
+func Test_when_get_single_key_input_then_return_rune(t *testing.T) {
 	tmp, _ := os.CreateTemp(t.TempDir(), "stdin")
 	tmp.WriteString("c\n")
 	tmp.Seek(0, 0)
@@ -130,7 +130,7 @@ func TestWhenGetSingleKeyInput_ShouldReturnRune(t *testing.T) {
 	}
 }
 
-func TestWhenGenerateNewScriptWithEmptyInput_ShouldShowWarning(t *testing.T) {
+func Test_when_generate_new_script_with_empty_input_then_show_warning(t *testing.T) {
 	tmp, _ := os.CreateTemp(t.TempDir(), "stdin")
 	tmp.WriteString("\n")
 	tmp.Seek(0, 0)
@@ -144,7 +144,7 @@ func TestWhenGenerateNewScriptWithEmptyInput_ShouldShowWarning(t *testing.T) {
 	}
 }
 
-func TestWhenGenerateNewScriptWithValidInput_ShouldAnnounceGeneration(t *testing.T) {
+func Test_when_generate_new_script_with_valid_input_then_announce_generation(t *testing.T) {
 	tmp, _ := os.CreateTemp(t.TempDir(), "stdin")
 	tmp.WriteString("test task\n")
 	tmp.Seek(0, 0)
@@ -158,7 +158,7 @@ func TestWhenGenerateNewScriptWithValidInput_ShouldAnnounceGeneration(t *testing
 	}
 }
 
-func TestWhenSaveToFile_ShouldCreateScriptFile(t *testing.T) {
+func Test_when_save_to_file_then_create_script_file(t *testing.T) {
 	tmpDir := t.TempDir()
 	tmp, _ := os.CreateTemp(t.TempDir(), "stdin")
 	tmp.WriteString("\n")

--- a/ui/interactive_risk_test.go
+++ b/ui/interactive_risk_test.go
@@ -1,0 +1,113 @@
+package ui
+
+import "testing"
+
+// Test determineRiskLevel function
+func Test_when_warnings_contain_red_prefix_then_return_red(t *testing.T) {
+	// Arrange
+	warnings := []string{
+		"🟡 Medium risk operation",
+		"⛔ CRITICAL: High risk detected",
+		"🟡 Another medium warning",
+	}
+
+	// Act
+	result := determineRiskLevel(warnings)
+
+	// Assert
+	if result != "red" {
+		t.Errorf("Expected 'red', got '%s'", result)
+	}
+}
+
+func Test_when_warnings_contain_only_red_color_prefix_then_return_red(t *testing.T) {
+	// Arrange
+	warnings := []string{
+		"🔴 High risk operation detected",
+	}
+
+	// Act
+	result := determineRiskLevel(warnings)
+
+	// Assert
+	if result != "red" {
+		t.Errorf("Expected 'red', got '%s'", result)
+	}
+}
+
+func Test_when_warnings_contain_only_yellow_prefix_then_return_yellow(t *testing.T) {
+	// Arrange
+	warnings := []string{
+		"🟡 Medium risk operation",
+		"🟡 Another medium warning",
+	}
+
+	// Act
+	result := determineRiskLevel(warnings)
+
+	// Assert
+	if result != "yellow" {
+		t.Errorf("Expected 'yellow', got '%s'", result)
+	}
+}
+
+func Test_when_warnings_contain_no_risk_prefixes_then_return_green(t *testing.T) {
+	// Arrange
+	warnings := []string{
+		"✅ Safe operation",
+		"ℹ️ Information message",
+		"This is a normal warning",
+	}
+
+	// Act
+	result := determineRiskLevel(warnings)
+
+	// Assert
+	if result != "green" {
+		t.Errorf("Expected 'green', got '%s'", result)
+	}
+}
+
+func Test_when_warnings_is_empty_then_return_green(t *testing.T) {
+	// Arrange
+	warnings := []string{}
+
+	// Act
+	result := determineRiskLevel(warnings)
+
+	// Assert
+	if result != "green" {
+		t.Errorf("Expected 'green', got '%s'", result)
+	}
+}
+
+func Test_when_warnings_is_nil_then_return_green(t *testing.T) {
+	// Arrange
+	var warnings []string = nil
+
+	// Act
+	result := determineRiskLevel(warnings)
+
+	// Assert
+	if result != "green" {
+		t.Errorf("Expected 'green', got '%s'", result)
+	}
+}
+
+func Test_when_warnings_contain_both_red_and_yellow_then_return_red(t *testing.T) {
+	// Arrange
+	warnings := []string{
+		"🟡 Medium risk operation",
+		"⛔ CRITICAL: High risk detected",
+		"🟡 Another medium warning",
+		"🔴 High risk operation",
+	}
+
+	// Act
+	result := determineRiskLevel(warnings)
+
+	// Assert
+	if result != "red" {
+		t.Errorf("Expected 'red' when both red and yellow present, got '%s'", result)
+	}
+}

--- a/ui/interactive_test.go
+++ b/ui/interactive_test.go
@@ -1,556 +1,12 @@
 package ui
 
 import (
-	"io"
-	"os"
-	"path/filepath"
-	"runtime"
-	"strings"
 	"testing"
 
 	"please/types"
 )
 
-// Test determineRiskLevel function
-func Test_when_warnings_contain_red_prefix_should_return_red(t *testing.T) {
-	// Arrange
-	warnings := []string{
-		"🟡 Medium risk operation",
-		"⛔ CRITICAL: High risk detected",
-		"🟡 Another medium warning",
-	}
-
-	// Act
-	result := determineRiskLevel(warnings)
-
-	// Assert
-	if result != "red" {
-		t.Errorf("Expected 'red', got '%s'", result)
-	}
-}
-
-func Test_when_warnings_contain_only_red_color_prefix_should_return_red(t *testing.T) {
-	// Arrange
-	warnings := []string{
-		"🔴 High risk operation detected",
-	}
-
-	// Act
-	result := determineRiskLevel(warnings)
-
-	// Assert
-	if result != "red" {
-		t.Errorf("Expected 'red', got '%s'", result)
-	}
-}
-
-func Test_when_warnings_contain_only_yellow_prefix_should_return_yellow(t *testing.T) {
-	// Arrange
-	warnings := []string{
-		"🟡 Medium risk operation",
-		"🟡 Another medium warning",
-	}
-
-	// Act
-	result := determineRiskLevel(warnings)
-
-	// Assert
-	if result != "yellow" {
-		t.Errorf("Expected 'yellow', got '%s'", result)
-	}
-}
-
-func Test_when_warnings_contain_no_risk_prefixes_should_return_green(t *testing.T) {
-	// Arrange
-	warnings := []string{
-		"✅ Safe operation",
-		"ℹ️ Information message",
-		"This is a normal warning",
-	}
-
-	// Act
-	result := determineRiskLevel(warnings)
-
-	// Assert
-	if result != "green" {
-		t.Errorf("Expected 'green', got '%s'", result)
-	}
-}
-
-func Test_when_warnings_is_empty_should_return_green(t *testing.T) {
-	// Arrange
-	warnings := []string{}
-
-	// Act
-	result := determineRiskLevel(warnings)
-
-	// Assert
-	if result != "green" {
-		t.Errorf("Expected 'green', got '%s'", result)
-	}
-}
-
-func Test_when_warnings_is_nil_should_return_green(t *testing.T) {
-	// Arrange
-	var warnings []string = nil
-
-	// Act
-	result := determineRiskLevel(warnings)
-
-	// Assert
-	if result != "green" {
-		t.Errorf("Expected 'green', got '%s'", result)
-	}
-}
-
-func Test_when_warnings_contain_both_red_and_yellow_should_return_red(t *testing.T) {
-	// Arrange
-	warnings := []string{
-		"🟡 Medium risk operation",
-		"⛔ CRITICAL: High risk detected",
-		"🟡 Another medium warning",
-		"🔴 High risk operation",
-	}
-
-	// Act
-	result := determineRiskLevel(warnings)
-
-	// Assert
-	if result != "red" {
-		t.Errorf("Expected 'red' when both red and yellow present, got '%s'", result)
-	}
-}
-
-// Test extractJSONField function
-func Test_when_extracting_valid_field_should_return_correct_value(t *testing.T) {
-	// Arrange
-	content := `{
-  "task_description": "list all files",
-  "script": "ls -la",
-  "script_type": "bash"
-}`
-	field := "task_description"
-	expected := "list all files"
-
-	// Act
-	result := extractJSONField(content, field)
-
-	// Assert
-	if result != expected {
-		t.Errorf("Expected '%s', got '%s'", expected, result)
-	}
-}
-
-func Test_when_extracting_script_field_should_return_correct_value(t *testing.T) {
-	// Arrange
-	content := `{
-  "task_description": "create backup",
-  "script": "cp /home/user /backup",
-  "script_type": "bash"
-}`
-	field := "script"
-	expected := "cp /home/user /backup"
-
-	// Act
-	result := extractJSONField(content, field)
-
-	// Assert
-	if result != expected {
-		t.Errorf("Expected '%s', got '%s'", expected, result)
-	}
-}
-
-func Test_when_extracting_nonexistent_field_should_return_empty_string(t *testing.T) {
-	// Arrange
-	content := `{
-  "task_description": "list all files",
-  "script": "ls -la"
-}`
-	field := "nonexistent_field"
-
-	// Act
-	result := extractJSONField(content, field)
-
-	// Assert
-	if result != "" {
-		t.Errorf("Expected empty string for nonexistent field, got '%s'", result)
-	}
-}
-
-func Test_when_extracting_from_empty_content_should_return_empty_string(t *testing.T) {
-	// Arrange
-	content := ""
-	field := "task_description"
-
-	// Act
-	result := extractJSONField(content, field)
-
-	// Assert
-	if result != "" {
-		t.Errorf("Expected empty string for empty content, got '%s'", result)
-	}
-}
-
-func Test_when_extracting_field_with_escaped_quotes_should_return_unescaped_value(t *testing.T) {
-	// Arrange
-	content := `{
-  "task_description": "create a \"hello world\" script",
-  "script": "echo \"hello\""
-}`
-	field := "task_description"
-	expected := `create a "hello world" script`
-
-	// Act
-	result := extractJSONField(content, field)
-
-	// Assert
-	if result != expected {
-		t.Errorf("Expected '%s', got '%s'", expected, result)
-	}
-}
-
-func Test_when_extracting_field_with_malformed_json_should_return_empty_string(t *testing.T) {
-	// Arrange
-	content := `{
-  "task_description": "incomplete json field`
-	field := "task_description"
-
-	// Act
-	result := extractJSONField(content, field)
-
-	// Assert
-	if result != "" {
-		t.Errorf("Expected empty string for malformed JSON, got '%s'", result)
-	}
-}
-
-// Test getConfigDir function
-func Test_when_getting_config_dir_should_return_platform_specific_path(t *testing.T) {
-	// Act
-	configDir, err := getConfigDir()
-
-	// Assert
-	if err != nil {
-		t.Errorf("Expected no error, got: %v", err)
-	}
-
-	if configDir == "" {
-		t.Error("Expected non-empty config directory path")
-	}
-
-	// Verify platform-specific path format
-	switch runtime.GOOS {
-	case "windows":
-		if !strings.Contains(configDir, "please") {
-			t.Errorf("Expected Windows config dir to contain 'please', got: %s", configDir)
-		}
-	case "darwin":
-		if !strings.Contains(configDir, "Library/Application Support") {
-			t.Errorf("Expected macOS config dir to contain 'Library/Application Support', got: %s", configDir)
-		}
-	default: // Linux and others
-		if !strings.Contains(configDir, ".config") {
-			t.Errorf("Expected Linux config dir to contain '.config', got: %s", configDir)
-		}
-	}
-}
-
-func Test_when_getting_config_dir_should_create_directory_if_not_exists(t *testing.T) {
-	// Act
-	configDir, err := getConfigDir()
-
-	// Assert
-	if err != nil {
-		t.Errorf("Expected no error, got: %v", err)
-	}
-
-	// Verify directory was created
-	if _, statErr := os.Stat(configDir); os.IsNotExist(statErr) {
-		t.Errorf("Expected config directory to be created at: %s", configDir)
-	}
-}
-
-// Test handleMainMenuChoice function
-func Test_when_choice_is_enter_should_return_true_for_exit(t *testing.T) {
-	// Arrange
-	choice := "\r"
-
-	// Act
-	result := handleMainMenuChoice(choice)
-
-	// Assert
-	if !result {
-		t.Error("Expected handleMainMenuChoice to return true for Enter key")
-	}
-}
-
-func Test_when_choice_is_newline_should_return_true_for_exit(t *testing.T) {
-	// Arrange
-	choice := "\n"
-
-	// Act
-	result := handleMainMenuChoice(choice)
-
-	// Assert
-	if !result {
-		t.Error("Expected handleMainMenuChoice to return true for newline")
-	}
-}
-
-func Test_when_choice_is_empty_should_return_false_to_continue(t *testing.T) {
-	// Arrange
-	choice := ""
-
-	// Act
-	result := handleMainMenuChoice(choice)
-
-	// Assert
-	if result {
-		t.Error("Expected handleMainMenuChoice to return false for empty choice")
-	}
-}
-
-func Test_when_choice_is_space_should_return_false_to_continue(t *testing.T) {
-	// Arrange
-	choice := " "
-
-	// Act
-	result := handleMainMenuChoice(choice)
-
-	// Assert
-	if result {
-		t.Error("Expected handleMainMenuChoice to return false for space")
-	}
-}
-
-func Test_when_choice_is_6_should_return_true_for_exit(t *testing.T) {
-	// Arrange
-	choice := "6"
-
-	// Act
-	result := handleMainMenuChoice(choice)
-
-	// Assert
-	if !result {
-		t.Error("Expected handleMainMenuChoice to return true for choice '6' (exit)")
-	}
-}
-
-func Test_when_choice_is_1_should_return_false_to_continue(t *testing.T) {
-	// Arrange
-	choice := "1"
-
-	// Act
-	result := handleMainMenuChoice(choice)
-
-	// Assert
-	if result {
-		t.Error("Expected handleMainMenuChoice to return false for choice '1' (help)")
-	}
-}
-
-func Test_when_choice_is_invalid_should_return_false_to_continue(t *testing.T) {
-	// Arrange
-	choice := "invalid"
-
-	// Act
-	result := handleMainMenuChoice(choice)
-
-	// Assert
-	if result {
-		t.Error("Expected handleMainMenuChoice to return false for invalid choice")
-	}
-}
-
-// Test saveLastScript and loadLastScriptData functions
-func Test_when_saving_and_loading_last_script_should_preserve_data(t *testing.T) {
-	// Arrange - create temporary directory for testing
-	tempDir := t.TempDir()
-
-	// Mock the getConfigDir function behavior by setting up the file in temp dir
-	response := &types.ScriptResponse{
-		TaskDescription: "test task",
-		Script:          "echo 'hello world'",
-		ScriptType:      "bash",
-		Model:           "test-model",
-		Provider:        "test-provider",
-	}
-
-	// Save the script to temp directory directly
-	lastScriptPath := filepath.Join(tempDir, "last_script.json")
-	jsonContent := `{
-  "task_description": "test task",
-  "script": "echo 'hello world'",
-  "script_type": "bash",
-  "model": "test-model",
-  "provider": "test-provider"
-}`
-	err := os.WriteFile(lastScriptPath, []byte(jsonContent), 0644)
-	if err != nil {
-		t.Fatalf("Failed to write test file: %v", err)
-	}
-
-	// Act - read and parse the saved data
-	data, err := os.ReadFile(lastScriptPath)
-	if err != nil {
-		t.Fatalf("Failed to read test file: %v", err)
-	}
-
-	content := string(data)
-	taskDesc := extractJSONField(content, "task_description")
-	script := extractJSONField(content, "script")
-	scriptType := extractJSONField(content, "script_type")
-	model := extractJSONField(content, "model")
-	provider := extractJSONField(content, "provider")
-
-	// Assert
-	if taskDesc != response.TaskDescription {
-		t.Errorf("Expected task description '%s', got '%s'", response.TaskDescription, taskDesc)
-	}
-	if script != response.Script {
-		t.Errorf("Expected script '%s', got '%s'", response.Script, script)
-	}
-	if scriptType != response.ScriptType {
-		t.Errorf("Expected script type '%s', got '%s'", response.ScriptType, scriptType)
-	}
-	if model != response.Model {
-		t.Errorf("Expected model '%s', got '%s'", response.Model, model)
-	}
-	if provider != response.Provider {
-		t.Errorf("Expected provider '%s', got '%s'", response.Provider, provider)
-	}
-}
-
-func Test_when_loading_nonexistent_last_script_should_return_nil(t *testing.T) {
-	// Act
-	result := loadLastScriptData()
-
-	// Assert - should return nil for nonexistent file
-	// Note: This test depends on the actual implementation,
-	// but verifies the function handles missing files gracefully
-	if result != nil {
-		// If it returns something, verify it's a valid response structure
-		if result.TaskDescription == "" && result.Script == "" {
-			// This is acceptable - function may return empty struct instead of nil
-		}
-	}
-}
-
-// Test file handling with escaped content
-func Test_when_script_contains_special_characters_should_handle_escaping(t *testing.T) {
-	// Arrange
-	content := `{
-  "task_description": "create \"complex\" script with \\ backslashes",
-  "script": "echo \"hello \\\"world\\\"\"",
-  "script_type": "bash"
-}`
-
-	// Act
-	taskDesc := extractJSONField(content, "task_description")
-	script := extractJSONField(content, "script")
-
-	// Assert
-	expectedTask := `create "complex" script with \ backslashes`
-	expectedScript := `echo "hello \"world\""`
-
-	if taskDesc != expectedTask {
-		t.Errorf("Expected task description '%s', got '%s'", expectedTask, taskDesc)
-	}
-	if script != expectedScript {
-		t.Errorf("Expected script '%s', got '%s'", expectedScript, script)
-	}
-}
-
-// Test renderMenu behavior with input injection
-func Test_when_renderMenu_with_injected_input_should_handle_choice(t *testing.T) {
-	// Arrange
-	callCount := 0
-	items := []MenuItem{
-		{Label: "Test Option", Icon: "🧪", Color: ColorGreen, Action: func() bool {
-			callCount++
-			return true // Exit after first call
-		}},
-	}
-
-	// Mock input function that returns '1' (first option)
-	mockInput := func() rune {
-		return '1'
-	}
-
-	// Act
-	renderMenu("Test Menu", "Choose: ", items, mockInput)
-
-	// Assert
-	if callCount != 1 {
-		t.Errorf("Expected action to be called once, called %d times", callCount)
-	}
-}
-
-func Test_when_renderMenu_with_enter_input_should_exit_immediately(t *testing.T) {
-	// Arrange
-	callCount := 0
-	items := []MenuItem{
-		{Label: "Test Option", Icon: "🧪", Color: ColorGreen, Action: func() bool {
-			callCount++
-			return false
-		}},
-	}
-
-	// Mock input function that returns Enter
-	mockInput := func() rune {
-		return '\r'
-	}
-
-	// Act
-	renderMenu("Test Menu", "Choose: ", items, mockInput)
-
-	// Assert
-	if callCount != 0 {
-		t.Errorf("Expected no action calls for Enter key, called %d times", callCount)
-	}
-}
-
-func Test_when_renderMenu_with_invalid_choice_should_continue_loop(t *testing.T) {
-	// Arrange
-	callCount := 0
-	items := []MenuItem{
-		{Label: "Test Option", Icon: "🧪", Color: ColorGreen, Action: func() bool {
-			callCount++
-			return true // Exit when called
-		}},
-	}
-
-	inputSequence := []rune{'9', '1'} // Invalid choice, then valid choice
-	inputIndex := 0
-
-	mockInput := func() rune {
-		result := inputSequence[inputIndex]
-		inputIndex++
-		return result
-	}
-
-	// Act
-	renderMenu("Test Menu", "Choose: ", items, mockInput)
-
-	// Assert
-	if callCount != 1 {
-		t.Errorf("Expected action to be called once after invalid choice, called %d times", callCount)
-	}
-}
-
-// Helper function to capture output for testing
-func captureOutput(fn func()) string {
-	r, w, _ := os.Pipe()
-	old := os.Stdout
-	os.Stdout = w
-	fn()
-	w.Close()
-	os.Stdout = old
-	data, _ := io.ReadAll(r)
-	return string(data)
-}
-
-func Test_when_showing_detailed_explanation_should_display_script_analysis(t *testing.T) {
+func Test_when_showing_detailed_explanation_then_display_script_analysis(t *testing.T) {
 	// Given: A script response with test data
 	response := &types.ScriptResponse{
 		TaskDescription: "test task",
@@ -571,7 +27,7 @@ func Test_when_showing_detailed_explanation_should_display_script_analysis(t *te
 	}()
 }
 
-func Test_when_copying_to_clipboard_should_handle_success_and_failure(t *testing.T) {
+func Test_when_copying_to_clipboard_then_handle_success_and_failure(t *testing.T) {
 	// Given: A script response
 	response := &types.ScriptResponse{
 		Script: "echo 'test script'",
@@ -588,7 +44,7 @@ func Test_when_copying_to_clipboard_should_handle_success_and_failure(t *testing
 	}()
 }
 
-func Test_when_generating_new_script_should_handle_empty_and_valid_input(t *testing.T) {
+func Test_when_generating_new_script_then_handle_empty_and_valid_input(t *testing.T) {
 	// Test that generateNewScript executes without panic when called
 	// Note: This function reads from stdin, so we test basic execution
 	defer func() {
@@ -601,7 +57,7 @@ func Test_when_generating_new_script_should_handle_empty_and_valid_input(t *test
 	// In actual usage, this would prompt user for input
 }
 
-func Test_when_browsing_history_should_show_coming_soon_message(t *testing.T) {
+func Test_when_browsing_history_then_show_coming_soon_message(t *testing.T) {
 	// When: Browsing history (should not panic)
 	func() {
 		defer func() {
@@ -613,7 +69,7 @@ func Test_when_browsing_history_should_show_coming_soon_message(t *testing.T) {
 	}()
 }
 
-func Test_when_showing_configuration_should_display_settings(t *testing.T) {
+func Test_when_showing_configuration_then_display_settings(t *testing.T) {
 	// When: Showing configuration (should not panic)
 	func() {
 		defer func() {
@@ -625,7 +81,7 @@ func Test_when_showing_configuration_should_display_settings(t *testing.T) {
 	}()
 }
 
-func Test_when_saving_to_history_should_create_json_entry(t *testing.T) {
+func Test_when_saving_to_history_then_create_json_entry(t *testing.T) {
 	// Given: A script response
 	response := &types.ScriptResponse{
 		TaskDescription: "test history task",
@@ -646,7 +102,7 @@ func Test_when_saving_to_history_should_create_json_entry(t *testing.T) {
 	}()
 }
 
-func Test_when_saving_last_script_should_create_json_file(t *testing.T) {
+func Test_when_saving_last_script_then_create_json_file(t *testing.T) {
 	// Given: A script response
 	response := &types.ScriptResponse{
 		TaskDescription: "test last script",
@@ -667,7 +123,7 @@ func Test_when_saving_last_script_should_create_json_file(t *testing.T) {
 	}()
 }
 
-func Test_when_getting_single_key_input_should_handle_platform_differences(t *testing.T) {
+func Test_when_getting_single_key_input_then_handle_platform_differences(t *testing.T) {
 	// Test that getSingleKeyInput functions exist and can be called without immediate panic
 	// Note: We can't actually test these functions as they wait for user input
 	// Instead, we test that the functions are defined and available
@@ -692,7 +148,7 @@ func Test_when_getting_single_key_input_should_handle_platform_differences(t *te
 	}
 }
 
-func Test_when_executing_script_with_different_risk_levels_should_handle_appropriately(t *testing.T) {
+func Test_when_executing_script_with_different_risk_levels_then_handle_appropriately(t *testing.T) {
 	// Given: Script responses with different risk levels
 	greenResponse := &types.ScriptResponse{
 		Script: "echo 'safe command'",
@@ -725,7 +181,7 @@ func Test_when_executing_script_with_different_risk_levels_should_handle_appropr
 	}
 }
 
-func Test_when_showing_main_menu_should_initialize_properly(t *testing.T) {
+func Test_when_showing_main_menu_then_initialize_properly(t *testing.T) {
 	// When: Showing main menu (should not panic)
 	defer func() {
 		if r := recover(); r != nil {
@@ -737,7 +193,7 @@ func Test_when_showing_main_menu_should_initialize_properly(t *testing.T) {
 	// In test environment, it should handle gracefully
 }
 
-func Test_when_showing_script_menu_should_handle_response_properly(t *testing.T) {
+func Test_when_showing_script_menu_then_handle_response_properly(t *testing.T) {
 	// Given: A script response
 	response := &types.ScriptResponse{
 		TaskDescription: "test task",
@@ -763,7 +219,7 @@ func Test_when_showing_script_menu_should_handle_response_properly(t *testing.T)
 	}
 }
 
-func Test_when_trying_auto_fix_should_handle_errors_gracefully(t *testing.T) {
+func Test_when_trying_auto_fix_then_handle_errors_gracefully(t *testing.T) {
 	// Given: A script response and error message
 	response := &types.ScriptResponse{
 		Script:     "echo 'broken script'",
@@ -789,7 +245,7 @@ func Test_when_trying_auto_fix_should_handle_errors_gracefully(t *testing.T) {
 	}
 }
 
-func Test_when_running_last_script_from_cli_should_handle_missing_script(t *testing.T) {
+func Test_when_running_last_script_from_cli_then_handle_missing_script(t *testing.T) {
 	// Test that RunLastScriptFromCLI function exists and can be called without immediate panic
 	// Note: We can't actually test this function as it runs interactively and waits for user input
 	// Instead, we test that the function is defined and available
@@ -817,7 +273,7 @@ func Test_when_running_last_script_from_cli_should_handle_missing_script(t *test
 	}
 }
 
-func Test_when_save_to_file_should_handle_user_input(t *testing.T) {
+func Test_when_save_to_file_then_handle_user_input(t *testing.T) {
 	// Given: A script response
 	response := &types.ScriptResponse{
 		TaskDescription: "test save",
@@ -838,7 +294,7 @@ func Test_when_save_to_file_should_handle_user_input(t *testing.T) {
 	}
 }
 
-func Test_when_edit_script_should_show_options_menu(t *testing.T) {
+func Test_when_edit_script_then_show_options_menu(t *testing.T) {
 	// Given: A script response
 	response := &types.ScriptResponse{
 		Script: "echo 'edit test'",
@@ -857,7 +313,7 @@ func Test_when_edit_script_should_show_options_menu(t *testing.T) {
 	}
 }
 
-func Test_when_refine_script_should_show_coming_soon_message(t *testing.T) {
+func Test_when_refine_script_then_show_coming_soon_message(t *testing.T) {
 	// Given: A script response
 	response := &types.ScriptResponse{
 		Script: "echo 'refine test'",
@@ -875,7 +331,7 @@ func Test_when_refine_script_should_show_coming_soon_message(t *testing.T) {
 }
 
 // Test UIService dependency injection functionality
-func Test_when_creating_ui_service_with_valid_config_dir_should_initialize_successfully(t *testing.T) {
+func Test_when_creating_ui_service_with_valid_config_dir_then_initialize_successfully(t *testing.T) {
 	// Given: A temporary config directory
 	tempDir := t.TempDir()
 
@@ -894,7 +350,7 @@ func Test_when_creating_ui_service_with_valid_config_dir_should_initialize_succe
 	}
 }
 
-func Test_when_creating_ui_service_with_invalid_config_dir_should_fallback_gracefully(t *testing.T) {
+func Test_when_creating_ui_service_with_invalid_config_dir_then_fallback_gracefully(t *testing.T) {
 	// Given: An invalid config directory path
 	invalidDir := "/this/path/does/not/exist/and/cannot/be/created"
 
@@ -913,7 +369,7 @@ func Test_when_creating_ui_service_with_invalid_config_dir_should_fallback_grace
 	}
 }
 
-func Test_when_ui_service_shows_main_menu_should_use_injected_localization_manager(t *testing.T) {
+func Test_when_ui_service_shows_main_menu_then_use_injected_localization_manager(t *testing.T) {
 	// Given: A UI service with initialized dependencies
 	tempDir := t.TempDir()
 	uiService, err := NewUIService(tempDir)
@@ -937,7 +393,7 @@ func Test_when_ui_service_shows_main_menu_should_use_injected_localization_manag
 	// so we just verify the service is properly structured
 }
 
-func Test_when_show_main_menu_called_should_create_ui_service_and_delegate(t *testing.T) {
+func Test_when_show_main_menu_called_then_create_ui_service_and_delegate(t *testing.T) {
 	// When: Calling ShowMainMenu (should not panic and should create UI service internally)
 	defer func() {
 		if r := recover(); r != nil {
@@ -951,7 +407,7 @@ func Test_when_show_main_menu_called_should_create_ui_service_and_delegate(t *te
 }
 
 // Test to verify global variable can be eliminated through dependency injection
-func Test_when_handle_main_menu_choice_should_work_without_global_localization_manager(t *testing.T) {
+func Test_when_handle_main_menu_choice_then_work_without_global_localization_manager(t *testing.T) {
 	// Given: No global locManager (this tests the future state without global variables)
 	// When: Calling handleMainMenuChoice with Enter key
 	choice := "\r"

--- a/ui/progress_test.go
+++ b/ui/progress_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 // TestProgressIndicator_ShowsStatusMessages tests that progress indicators display status
-func TestProgressIndicator_ShowsStatusMessages(t *testing.T) {
+func Test_when_progress_indicator_then_shows_status_messages(t *testing.T) {
 	// Create a progress indicator
 	progress := NewProgressIndicator("Testing operation")
 
@@ -30,7 +30,7 @@ func TestProgressIndicator_ShowsStatusMessages(t *testing.T) {
 }
 
 // TestProgressIndicator_UpdateStatus tests status updates
-func TestProgressIndicator_UpdateStatus(t *testing.T) {
+func Test_when_progress_indicator_then_update_status(t *testing.T) {
 	progress := NewProgressIndicator("Initial message")
 
 	// Update the status
@@ -42,7 +42,7 @@ func TestProgressIndicator_UpdateStatus(t *testing.T) {
 }
 
 // TestProgressIndicator_StartStop tests start and stop functionality
-func TestProgressIndicator_StartStop(t *testing.T) {
+func Test_when_progress_indicator_then_start_stop(t *testing.T) {
 	progress := NewProgressIndicator("Test message")
 
 	// Start the progress indicator
@@ -146,21 +146,21 @@ func TestAutoFixProgress(t *testing.T) {
 	}
 }
 
-func TestWhenShowSimpleProgress_ShouldStopCleanly(t *testing.T) {
+func Test_when_show_simple_progress_then_stop_cleanly(t *testing.T) {
 	os.Setenv("PROGRESS_TEST_MODE", "1")
 	stop := ShowSimpleProgress("doing work")
 	time.Sleep(100 * time.Millisecond)
 	stop()
 }
 
-func TestWhenShowProviderProgress_ShouldStopCleanly(t *testing.T) {
+func Test_when_show_provider_progress_then_stop_cleanly(t *testing.T) {
 	os.Setenv("PROGRESS_TEST_MODE", "1")
 	stop := ShowProviderProgress("openai", "testing")
 	time.Sleep(100 * time.Millisecond)
 	stop()
 }
 
-func TestWhenShowProgressWithSteps_ShouldRunSteps(t *testing.T) {
+func Test_when_show_progress_with_steps_then_run_steps(t *testing.T) {
 	os.Setenv("PROGRESS_TEST_MODE", "1")
 	start := time.Now()
 	ShowProgressWithSteps([]string{"one"})
@@ -169,7 +169,7 @@ func TestWhenShowProgressWithSteps_ShouldRunSteps(t *testing.T) {
 	}
 }
 
-func TestWhenAutoFixErrorContainsPermission_ShouldAddPermissionMessage(t *testing.T) {
+func Test_when_auto_fix_error_contains_permission_then_add_permission_message(t *testing.T) {
 	messages := GetAutoFixProgressMessages(strings.Repeat("a", 100), "permission denied", "openai")
 	found := false
 	for _, m := range messages {
@@ -183,7 +183,7 @@ func TestWhenAutoFixErrorContainsPermission_ShouldAddPermissionMessage(t *testin
 	}
 }
 
-func TestWhenAutoFixScriptVeryLarge_ShouldAddLargeScriptMessage(t *testing.T) {
+func Test_when_auto_fix_script_very_large_then_add_large_script_message(t *testing.T) {
 	script := strings.Repeat("x", 600)
 	messages := GetAutoFixProgressMessages(script, "other", "anthropic")
 	last := messages[len(messages)-1]


### PR DESCRIPTION
## Summary
- split huge interactive_test.go into focused test files
- rename tests throughout to `Test_when_x_then_y` format
- clean imports after splitting tests

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684d277f580c8321b9b66eb55caf2efa