### PR TITLE
Implement localization & theming tests

### DIFF
--- a/localization/integration_test.go
+++ b/localization/integration_test.go
@@ -1,0 +1,13 @@
+package localization
+
+import "testing"
+
+func TestWhenInitializingManager_ShouldLoadDefaultEnglish(t *testing.T) {
+	mgr, err := NewLocalizationManager("..")
+	if err != nil {
+		t.Fatalf("init error: %v", err)
+	}
+	if msg := mgr.GetMessage("footer.happy"); msg == "" {
+		t.Errorf("expected default footer message")
+	}
+}

--- a/localization/manager.go
+++ b/localization/manager.go
@@ -104,6 +104,22 @@ func getFromConfig(cfg *types.LocalizationConfig, cat, field string) string {
 		if field == "enter_request" {
 			return cfg.Messages.Prompts.EnterRequest
 		}
+	case "installation":
+		switch field {
+		case "success":
+			return cfg.Messages.Installation.Success
+		case "try_it":
+			return cfg.Messages.Installation.TryIt
+		case "magic":
+			return cfg.Messages.Installation.Magic
+		}
+	case "footer":
+		switch field {
+		case "tips":
+			return cfg.Messages.Footer.Tips
+		case "happy":
+			return cfg.Messages.Footer.Happy
+		}
 	}
 	return ""
 }

--- a/localization/manager_bdd_test.go
+++ b/localization/manager_bdd_test.go
@@ -1,0 +1,46 @@
+package localization
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"please/types"
+)
+
+func TestWhenLoadingLanguageFile_ShouldReturnMessages(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "en.json")
+	os.WriteFile(file, []byte(`{"language":"en","theme":"default","messages":{"banner":{"title":"Hi"}}}`), 0644)
+	mgr, err := NewLocalizationManager(dir)
+	if err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	mgr.LoadLanguage("en", file)
+	mgr.SetLanguage("en")
+	if msg := mgr.GetMessage("banner.title"); msg != "Hi" {
+		t.Errorf("expected Hi, got %s", msg)
+	}
+}
+
+func TestWhenLanguageMissing_ShouldFallbackToDefaults(t *testing.T) {
+	mgr, err := NewLocalizationManager("..")
+	if err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	if mgr.GetMessage("banner.title") == "" {
+		t.Errorf("expected default title")
+	}
+}
+
+func TestWhenSwitchingTheme_ShouldReturnUpdatedColor(t *testing.T) {
+	mgr := &LocalizationManager{config: &types.LocalizationConfig{Themes: types.Theme{Colors: map[string]string{"primary": "#fff"}}}, themes: make(map[string]types.Theme)}
+	mgr.LoadTheme("dark", types.Theme{Colors: map[string]string{"primary": "#000"}})
+	if mgr.GetThemeColor("primary") != "#fff" {
+		t.Errorf("expected default color")
+	}
+	mgr.SetTheme("dark")
+	if mgr.GetThemeColor("primary") != "#000" {
+		t.Errorf("expected dark color")
+	}
+}

--- a/themes/en-us.json
+++ b/themes/en-us.json
@@ -13,6 +13,15 @@
     "prompts": {
       "select_provider": "Select AI provider:",
       "enter_request": "What would you like me to help with?"
+    },
+    "installation": {
+      "success": "🎉 Installation complete! 🎉",
+      "try_it": "🚀 Try it out:",
+      "magic": "✨ Magic happens with just 3 letters: 'pls' ✨"
+    },
+    "footer": {
+      "tips": "💡 Tips:",
+      "happy": "🌟 Happy scripting! 🌟"
     }
   },
   "themes": {

--- a/themes/es-es.json
+++ b/themes/es-es.json
@@ -5,6 +5,15 @@
     "banner": {
       "title": "🤖 Please - Asistente Digital Muy Útil",
       "subtitle": "Generador de scripts multiplataforma"
+    },
+    "installation": {
+      "success": "🎉 Instalación completa! 🎉",
+      "try_it": "🚀 Pruébalo:",
+      "magic": "✨ La magia ocurre con solo 3 letras: 'pls' ✨"
+    },
+    "footer": {
+      "tips": "💡 Consejos:",
+      "happy": "🌟 Scripts felices! 🌟"
     }
   }
 }

--- a/themes/fr-fr.json
+++ b/themes/fr-fr.json
@@ -5,6 +5,15 @@
     "banner": {
       "title": "🤖 Please - Votre Assistant Numérique Très Utile",
       "subtitle": "Générateur de scripts multiplateforme"
+    },
+    "installation": {
+      "success": "🎉 Installation terminée ! 🎉",
+      "try_it": "🚀 Essayez :",
+      "magic": "✨ La magie opère avec seulement 3 lettres : 'pls' ✨"
+    },
+    "footer": {
+      "tips": "💡 Conseils :",
+      "happy": "🌟 Bon scripting ! 🌟"
     }
   }
 }

--- a/types/locconfig.go
+++ b/types/locconfig.go
@@ -2,8 +2,8 @@ package types
 
 // Banner holds banner title and subtitle
 type Banner struct {
-    Title    string `json:"title"`
-    Subtitle string `json:"subtitle"`
+	Title    string `json:"title"`
+	Subtitle string `json:"subtitle"`
 }
 
 // Errors holds error messages
@@ -18,11 +18,26 @@ type Prompts struct {
 	EnterRequest   string `json:"enter_request"`
 }
 
+// Installation holds installation messages
+type Installation struct {
+	Success string `json:"success"`
+	TryIt   string `json:"try_it"`
+	Magic   string `json:"magic"`
+}
+
+// Footer holds footer messages
+type Footer struct {
+	Tips  string `json:"tips"`
+	Happy string `json:"happy"`
+}
+
 // Messages groups all localized messages
 type Messages struct {
-	Banner  Banner  `json:"banner"`
-	Errors  Errors  `json:"errors"`
-	Prompts Prompts `json:"prompts"`
+	Banner       Banner       `json:"banner"`
+	Errors       Errors       `json:"errors"`
+	Prompts      Prompts      `json:"prompts"`
+	Installation Installation `json:"installation"`
+	Footer       Footer       `json:"footer"`
 }
 
 // Theme defines color mappings

--- a/ui/banner.go
+++ b/ui/banner.go
@@ -54,23 +54,49 @@ func PrintRainbowBannerWithDelay(delay time.Duration) {
 
 // PrintInstallationSuccess shows a fun success message
 func PrintInstallationSuccess() {
-	fmt.Printf("%s🎉 Installation complete! 🎉%s\n\n", ColorBold+ColorGreen, ColorReset)
-	fmt.Printf("%s🚀 Try it out:%s\n", ColorBold+ColorCyan, ColorReset)
+	success := "🎉 Installation complete! 🎉"
+	tryIt := "🚀 Try it out:"
+	magic := "✨ Magic happens with just 3 letters: 'pls' ✨"
+	if locMgr != nil {
+		if v := locMgr.GetMessage("installation.success"); v != "" {
+			success = v
+		}
+		if v := locMgr.GetMessage("installation.try_it"); v != "" {
+			tryIt = v
+		}
+		if v := locMgr.GetMessage("installation.magic"); v != "" {
+			magic = v
+		}
+	}
+
+	fmt.Printf("%s%s%s\n\n", ColorBold+ColorGreen, success, ColorReset)
+	fmt.Printf("%s%s%s\n", ColorBold+ColorCyan, tryIt, ColorReset)
 	fmt.Printf("  %spls create a hello world script%s\n", ColorYellow, ColorReset)
 	fmt.Printf("  %sol create a hello world script%s (legacy)\n\n", ColorYellow, ColorReset)
 
 	// Fun ASCII art
-	fmt.Printf("%s    ✨ Magic happens with just 3 letters: 'pls' ✨%s\n", ColorPurple, ColorReset)
+	fmt.Printf("%s    %s%s\n", ColorPurple, magic, ColorReset)
 }
 
 // PrintFooter shows colorful footer information
 func PrintFooter() {
-	fmt.Printf("%s💡 Tips:%s\n", ColorBold+ColorYellow, ColorReset)
+	tips := "💡 Tips:"
+	happy := "🌟 Happy scripting! 🌟"
+	if locMgr != nil {
+		if v := locMgr.GetMessage("footer.tips"); v != "" {
+			tips = v
+		}
+		if v := locMgr.GetMessage("footer.happy"); v != "" {
+			happy = v
+		}
+	}
+
+	fmt.Printf("%s%s%s\n", ColorBold+ColorYellow, tips, ColorReset)
 	fmt.Printf("  %s• Use natural language - no quotes needed!%s\n", ColorCyan, ColorReset)
 	fmt.Printf("  %s• Be specific for better results%s\n", ColorCyan, ColorReset)
 	fmt.Printf("  %s• Always review scripts before execution%s\n", ColorCyan, ColorReset)
 	fmt.Printf("  %s• Set PLEASE_PROVIDER=openai for OpenAI%s\n", ColorCyan, ColorReset)
 	fmt.Printf("  %s• Set PLEASE_PROVIDER=anthropic for Claude%s\n\n", ColorCyan, ColorReset)
 
-	fmt.Printf("%s🌟 Happy scripting! 🌟%s\n", ColorBold+ColorPurple, ColorReset)
+	fmt.Printf("%s%s%s\n", ColorBold+ColorPurple, happy, ColorReset)
 }

--- a/ui/banner_bdd_test.go
+++ b/ui/banner_bdd_test.go
@@ -1,0 +1,54 @@
+package ui
+
+import (
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"please/localization"
+)
+
+// helper to capture stdout
+func captureBannerOutput(fn func()) string {
+	return captureStdout(fn)
+}
+
+func TestWhenPrintingRainbowBannerWithDelay_ShouldRespectProvidedDelay(t *testing.T) {
+	start := time.Now()
+	PrintRainbowBannerWithDelay(2 * time.Millisecond)
+	if time.Since(start) < 10*time.Millisecond { // 6 lines * 2ms plus overhead
+		t.Errorf("expected banner to take at least 10ms")
+	}
+}
+
+func TestWhenPrintingInstallationSuccess_ShouldOutputInstallationCompleteMessage(t *testing.T) {
+	out := captureBannerOutput(PrintInstallationSuccess)
+	if !strings.Contains(out, "Installation complete") {
+		t.Errorf("expected installation message in output")
+	}
+}
+
+func TestWhenPrintingFooter_ShouldOutputHappyScripting(t *testing.T) {
+	out := captureBannerOutput(PrintFooter)
+	if !strings.Contains(out, "Happy scripting") {
+		t.Errorf("expected footer to mention happy scripting")
+	}
+}
+
+func TestWhenPrintingBannerWithLocalization_ShouldUseProvidedMessages(t *testing.T) {
+	dir := t.TempDir()
+	langPath := dir + "/test.json"
+	os.WriteFile(langPath, []byte(`{"language":"test","theme":"default","messages":{"banner":{"title":"Hola","subtitle":"Mundo"}}}`), 0644)
+	mgr, err := localization.NewLocalizationManager(dir)
+	if err != nil {
+		t.Fatalf("failed to create localization manager: %v", err)
+	}
+	mgr.LoadLanguage("test", langPath)
+	mgr.SetLanguage("test")
+	SetLocalizationManager(mgr)
+	out := captureBannerOutput(func() { PrintRainbowBannerWithDelay(0) })
+	if !strings.Contains(out, "Hola") || !strings.Contains(out, "Mundo") {
+		t.Errorf("expected localized messages in banner output: %s", out)
+	}
+}

--- a/ui/colors_bdd_test.go
+++ b/ui/colors_bdd_test.go
@@ -1,0 +1,34 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestWhenValidatingColorConstants_ShouldAllStartWithEscape(t *testing.T) {
+	colors := []string{ColorReset, ColorRed, ColorGreen, ColorYellow, ColorBlue, ColorPurple, ColorMagenta, ColorCyan, ColorWhite, ColorBold, ColorDim,
+		BgRed, BgGreen, BgYellow, BgBlue, BgPurple, BgCyan,
+		Rainbow1, Rainbow2, Rainbow3, Rainbow4, Rainbow5, Rainbow6, Rainbow7}
+	for _, c := range colors {
+		if !strings.HasPrefix(c, "\033[") {
+			t.Errorf("color %q missing escape prefix", c)
+		}
+	}
+}
+
+func TestWhenComparingMagentaAlias_ShouldEqualPurple(t *testing.T) {
+	if ColorMagenta != ColorPurple {
+		t.Errorf("expected magenta alias to equal purple")
+	}
+}
+
+func TestWhenCheckingRainbowColors_ShouldAllBeUnique(t *testing.T) {
+	colors := []string{Rainbow1, Rainbow2, Rainbow3, Rainbow4, Rainbow5, Rainbow6, Rainbow7}
+	set := map[string]struct{}{}
+	for _, c := range colors {
+		if _, ok := set[c]; ok {
+			t.Errorf("duplicate color %s", c)
+		}
+		set[c] = struct{}{}
+	}
+}

--- a/ui/help_bdd_test.go
+++ b/ui/help_bdd_test.go
@@ -1,0 +1,41 @@
+package ui
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"please/localization"
+)
+
+func captureHelpOutput(fn func()) string {
+	return captureStdoutForHelp(fn)
+}
+
+func TestWhenShowingHelpWithLocalization_ShouldUseLocalizedBannerTexts(t *testing.T) {
+	dir := t.TempDir()
+	langPath := dir + "/lang.json"
+	os.WriteFile(langPath, []byte(`{"language":"x","theme":"default","messages":{"banner":{"title":"Hola","subtitle":"Ayuda"}}}`), 0644)
+	mgr, err := localization.NewLocalizationManager(dir)
+	if err != nil {
+		t.Fatalf("failed to create manager: %v", err)
+	}
+	mgr.LoadLanguage("x", langPath)
+	mgr.SetLanguage("x")
+	SetLocalizationManagerForHelp(mgr)
+	out := captureHelpOutput(ShowHelp)
+	if !strings.Contains(out, "Hola") || !strings.Contains(out, "Ayuda") {
+		t.Errorf("expected localized banner text: %s", out)
+	}
+}
+
+func TestWhenShowHelpWithInjectedBanner_ShouldInvokeBanner(t *testing.T) {
+	called := false
+	out := captureHelpOutput(func() { showHelpWithBanner(func() { called = true }) })
+	if !called {
+		t.Error("expected injected banner to be called")
+	}
+	if out == "" {
+		t.Error("expected some output from help")
+	}
+}

--- a/ui/interactive_bdd_test.go
+++ b/ui/interactive_bdd_test.go
@@ -1,0 +1,168 @@
+package ui
+
+import (
+	"io"
+	"os"
+	"runtime"
+	"strings"
+	"testing"
+
+	"please/types"
+)
+
+// helper to capture stdout
+func captureInteractiveOutput(fn func()) string {
+	r, w, _ := os.Pipe()
+	old := os.Stdout
+	os.Stdout = w
+	fn()
+	w.Close()
+	os.Stdout = old
+	data, _ := io.ReadAll(r)
+	return string(data)
+}
+
+func setTempHome(t *testing.T) string {
+	dir := t.TempDir()
+	if runtime.GOOS == "windows" {
+		t.Setenv("APPDATA", dir)
+	} else {
+		t.Setenv("HOME", dir)
+	}
+	return dir
+}
+
+func TestWhenShowingMainMenuWithService_ShouldExitOnEnter(t *testing.T) {
+	dir := setTempHome(t)
+	ui, err := NewUIService(dir)
+	if err != nil {
+		t.Fatalf("failed to create service: %v", err)
+	}
+	tmp, _ := os.CreateTemp(t.TempDir(), "stdin")
+	tmp.WriteString("\n")
+	tmp.Seek(0, 0)
+	old := os.Stdin
+	os.Stdin = tmp
+	defer func() { os.Stdin = old }()
+
+	out := captureInteractiveOutput(func() { ui.ShowMainMenuWithService() })
+	if !strings.Contains(out, "Please Script Generator") {
+		t.Errorf("expected banner text in output, got: %s", out)
+	}
+}
+
+func TestWhenExecutingGreenScript_ShouldShowCompletion(t *testing.T) {
+	_ = setTempHome(t)
+	resp := &types.ScriptResponse{TaskDescription: "test", Script: "echo hi", ScriptType: "bash"}
+	tmp, _ := os.CreateTemp(t.TempDir(), "stdin")
+	tmp.WriteString("\n")
+	tmp.Seek(0, 0)
+	old := os.Stdin
+	os.Stdin = tmp
+	defer func() { os.Stdin = old }()
+
+	out := captureInteractiveOutput(func() { executeScript(resp) })
+	if !strings.Contains(out, "Executing safe script") {
+		t.Errorf("expected execute message, got: %s", out)
+	}
+}
+
+func TestWhenExecutingYellowScriptAndUserCancels_ShouldSkipExecution(t *testing.T) {
+	resp := &types.ScriptResponse{Script: "rm -rf temp", ScriptType: "bash"}
+	tmp, _ := os.CreateTemp(t.TempDir(), "stdin")
+	tmp.WriteString("n\n")
+	tmp.Seek(0, 0)
+	old := os.Stdin
+	os.Stdin = tmp
+	defer func() { os.Stdin = old }()
+
+	out := captureInteractiveOutput(func() { executeScript(resp) })
+	if !strings.Contains(out, "cancelled") {
+		t.Errorf("expected cancellation message, got: %s", out)
+	}
+}
+
+func TestWhenExecutingRedScriptAndUserCancels_ShouldWarnAndReturn(t *testing.T) {
+	resp := &types.ScriptResponse{Script: "rm -rf /", ScriptType: "bash"}
+	tmp, _ := os.CreateTemp(t.TempDir(), "stdin")
+	tmp.WriteString("\n")
+	tmp.Seek(0, 0)
+	old := os.Stdin
+	os.Stdin = tmp
+	defer func() { os.Stdin = old }()
+
+	out := captureInteractiveOutput(func() { executeScript(resp) })
+	if !strings.Contains(out, "HIGH RISK") {
+		t.Errorf("expected high risk warning, got: %s", out)
+	}
+}
+
+func TestWhenPrintAutoFixError_ShouldDisplaySuggestions(t *testing.T) {
+	resp := &types.ScriptResponse{Script: "echo hi"}
+	tmp, _ := os.CreateTemp(t.TempDir(), "stdin")
+	tmp.WriteString("\n")
+	tmp.Seek(0, 0)
+	old := os.Stdin
+	os.Stdin = tmp
+	defer func() { os.Stdin = old }()
+
+	out := captureInteractiveOutput(func() { printAutoFixError(io.EOF, resp) })
+	if !strings.Contains(out, "Auto-fix failed") {
+		t.Errorf("expected failure message, got: %s", out)
+	}
+}
+
+func TestWhenPrintAutoFixSuccess_ShouldShowFixedScript(t *testing.T) {
+	resp := &types.ScriptResponse{Script: "echo hi\necho bye"}
+	out := captureInteractiveOutput(func() { printAutoFixSuccess(resp) })
+	if !strings.Contains(out, "Auto-fix applied") {
+		t.Errorf("expected success message, got: %s", out)
+	}
+}
+
+func TestWhenTryAutoFixUnsupportedProvider_ShouldShowError(t *testing.T) {
+	setTempHome(t)
+	os.Setenv("PROGRESS_TEST_MODE", "1")
+	resp := &types.ScriptResponse{Script: "echo hi", ScriptType: "bash", Provider: "unknown"}
+	tmp, _ := os.CreateTemp(t.TempDir(), "stdin")
+	tmp.WriteString("\n")
+	tmp.Seek(0, 0)
+	old := os.Stdin
+	os.Stdin = tmp
+	defer func() { os.Stdin = old }()
+
+	out := captureInteractiveOutput(func() { tryAutoFix(resp, "oops") })
+	if !strings.Contains(out, "Auto-fix failed") {
+		t.Errorf("expected auto-fix error, got: %s", out)
+	}
+}
+
+func TestWhenShowPostActionMenuWithEnter_ShouldExitImmediately(t *testing.T) {
+	resp := &types.ScriptResponse{Script: "echo hi"}
+	tmp, _ := os.CreateTemp(t.TempDir(), "stdin")
+	tmp.WriteString("\n")
+	tmp.Seek(0, 0)
+	old := os.Stdin
+	os.Stdin = tmp
+	defer func() { os.Stdin = old }()
+
+	out := captureInteractiveOutput(func() { showPostActionMenu(resp) })
+	if !strings.Contains(out, "Quick exit") {
+		t.Errorf("expected quick exit, got: %s", out)
+	}
+}
+
+func TestWhenEditScriptWithEnter_ShouldExitMenu(t *testing.T) {
+	resp := &types.ScriptResponse{Script: "echo hi"}
+	tmp, _ := os.CreateTemp(t.TempDir(), "stdin")
+	tmp.WriteString("\n")
+	tmp.Seek(0, 0)
+	old := os.Stdin
+	os.Stdin = tmp
+	defer func() { os.Stdin = old }()
+
+	out := captureInteractiveOutput(func() { editScript(resp) })
+	if !strings.Contains(out, "Quick exit") {
+		t.Errorf("expected quick exit, got: %s", out)
+	}
+}

--- a/ui/progress_bdd_test.go
+++ b/ui/progress_bdd_test.go
@@ -1,0 +1,52 @@
+package ui
+
+import (
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"please/types"
+)
+
+func TestWhenGettingProviderStatusMessageUnknown_ShouldUseDefaultMessage(t *testing.T) {
+	SetLocalizationManager(nil)
+	msg := GetProviderStatusMessage("unknown")
+	if !strings.Contains(msg, "AI provider") {
+		t.Errorf("expected default provider message, got %s", msg)
+	}
+}
+
+func TestWhenShowProviderProgress_ShouldReturnStopFunction(t *testing.T) {
+	os.Setenv("PROGRESS_TEST_MODE", "1")
+	stop := ShowProviderProgress("openai", "testing")
+	time.Sleep(10 * time.Millisecond)
+	if stop == nil {
+		t.Fatal("expected stop func")
+	}
+	stop()
+}
+
+func TestWhenShowProgressWithSteps_ShouldIterateAllMessages(t *testing.T) {
+	os.Setenv("PROGRESS_TEST_MODE", "1")
+	start := time.Now()
+	ShowProgressWithSteps([]string{"one", "two"})
+	if time.Since(start) > 5*time.Second {
+		t.Errorf("progress took too long")
+	}
+}
+
+func TestWhenGettingScriptGenerationProgressMessages_ShouldIncludeProviderInit(t *testing.T) {
+	cfg := &types.Config{Provider: "openai", PreferredModel: "gpt"}
+	msgs := GetScriptGenerationProgressMessages(cfg)
+	found := false
+	for _, m := range msgs {
+		if strings.Contains(m, "openai") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected provider name in messages")
+	}
+}


### PR DESCRIPTION
## Summary
- add BDD-style tests for banner, help, progress, and colors
- improve localization manager testing
- localize installation and footer messages
- include Spanish and French translations
- integration test for localization defaults

## Testing
- `go test ./...`
- `go test ./ui -cover`
- `go test ./localization -cover`


------
https://chatgpt.com/codex/tasks/task_e_684d66371c848321a58efeafe0c91a29