### PR TITLE
Add localization BDD tests and flag parsing improvements

### DIFF
--- a/localization/manager.go
+++ b/localization/manager.go
@@ -120,6 +120,30 @@ func getFromConfig(cfg *types.LocalizationConfig, cat, field string) string {
 		case "happy":
 			return cfg.Messages.Footer.Happy
 		}
+	case "script_display":
+		switch field {
+		case "task_label":
+			return cfg.Messages.ScriptDisplay.TaskLabel
+		case "model_label":
+			return cfg.Messages.ScriptDisplay.ModelLabel
+		case "platform_label":
+			return cfg.Messages.ScriptDisplay.PlatformLabel
+		case "script_header":
+			return cfg.Messages.ScriptDisplay.ScriptHeader
+		case "success_message":
+			return cfg.Messages.ScriptDisplay.SuccessMessage
+		}
+	case "menu":
+		switch field {
+		case "generate_script":
+			return cfg.Messages.Menu.GenerateScript
+		case "run_last":
+			return cfg.Messages.Menu.RunLast
+		case "help":
+			return cfg.Messages.Menu.Help
+		case "exit":
+			return cfg.Messages.Menu.Exit
+		}
 	}
 	return ""
 }

--- a/localization/manager_test.go
+++ b/localization/manager_test.go
@@ -175,3 +175,18 @@ func Test_when_getting_missing_message_then_use_fallback(t *testing.T) {
 		t.Errorf("expected primary message")
 	}
 }
+func Test_when_getting_script_display_message_then_return_values(t *testing.T) {
+	temp := t.TempDir()
+	jsonPath := filepath.Join(temp, "sd.json")
+	content := `{
+  "language":"en-us","theme":"default",
+  "messages":{"script_display":{"task_label":"Task"}}
+}`
+	os.WriteFile(jsonPath, []byte(content), 0644)
+	mgr := &LocalizationManager{config: &types.LocalizationConfig{}}
+	mgr.files = map[string]string{"en": jsonPath}
+	mgr.SetLanguage("en")
+	if mgr.GetMessage("script_display.task_label") != "Task" {
+		t.Errorf("expected task label")
+	}
+}

--- a/main.go
+++ b/main.go
@@ -18,13 +18,17 @@ import (
 func main() {
 	lang := "en-us"
 	theme := "default"
+	args := []string{}
 	for _, arg := range os.Args[1:] {
 		if strings.HasPrefix(arg, "--language=") {
 			lang = strings.SplitN(arg, "=", 2)[1]
+			continue
 		}
 		if strings.HasPrefix(arg, "--theme=") {
 			theme = strings.SplitN(arg, "=", 2)[1]
+			continue
 		}
+		args = append(args, arg)
 	}
 
 	locMgr, _ := localization.NewLocalizationManager(".")
@@ -33,7 +37,7 @@ func main() {
 	locMgr.LoadTheme(theme, themeData)
 	locMgr.SetLanguage(lang)
 	locMgr.SetTheme(theme)
-	
+
 	// Set the global manager for backward compatibility bridge
 	ui.SetGlobalLocalizationManager(locMgr)
 
@@ -44,8 +48,8 @@ func main() {
 	}
 
 	// Handle special commands
-	if len(os.Args) >= 2 {
-		switch os.Args[1] {
+	if len(args) >= 1 {
+		switch args[0] {
 		case "--install-alias":
 			installAlias()
 			return
@@ -65,13 +69,13 @@ func main() {
 	}
 
 	// If no arguments provided, show interactive main menu
-	if len(os.Args) < 2 {
+	if len(args) < 1 {
 		ui.ShowMainMenu()
 		return
 	}
 
 	// Join all arguments after the program name as the task description
-	taskDescription := strings.Join(os.Args[1:], " ")
+	taskDescription := strings.Join(args, " ")
 
 	// Check for natural language history/last script commands
 	if isLastScriptCommand(taskDescription) {
@@ -167,12 +171,12 @@ func displayScriptAndConfirm(response *types.ScriptResponse) {
 	if taskLabel == "" {
 		taskLabel = "📝 Task:"
 	}
-	
+
 	modelLabel := ui.GetLocalizedMessage("script_display.model_label")
 	if modelLabel == "" {
 		modelLabel = "🧠 Model:"
 	}
-	
+
 	platformLabel := ui.GetLocalizedMessage("script_display.platform_label")
 	if platformLabel == "" {
 		platformLabel = "🖥️ Platform:"

--- a/types/locconfig.go
+++ b/types/locconfig.go
@@ -33,11 +33,28 @@ type Footer struct {
 
 // Messages groups all localized messages
 type Messages struct {
-	Banner       Banner       `json:"banner"`
-	Errors       Errors       `json:"errors"`
-	Prompts      Prompts      `json:"prompts"`
-	Installation Installation `json:"installation"`
-	Footer       Footer       `json:"footer"`
+	Banner        Banner        `json:"banner"`
+	Errors        Errors        `json:"errors"`
+	Prompts       Prompts       `json:"prompts"`
+	Installation  Installation  `json:"installation"`
+	ScriptDisplay ScriptDisplay `json:"script_display"`
+	Menu          Menu          `json:"menu"`
+	Footer        Footer        `json:"footer"`
+}
+
+type ScriptDisplay struct {
+	TaskLabel      string `json:"task_label"`
+	ModelLabel     string `json:"model_label"`
+	PlatformLabel  string `json:"platform_label"`
+	ScriptHeader   string `json:"script_header"`
+	SuccessMessage string `json:"success_message"`
+}
+
+type Menu struct {
+	GenerateScript string `json:"generate_script"`
+	RunLast        string `json:"run_last"`
+	Help           string `json:"help"`
+	Exit           string `json:"exit"`
 }
 
 // Theme defines color mappings

--- a/ui/banner_bdd_test.go
+++ b/ui/banner_bdd_test.go
@@ -47,6 +47,7 @@ func TestWhenPrintingBannerWithLocalization_ShouldUseProvidedMessages(t *testing
 	mgr.LoadLanguage("test", langPath)
 	mgr.SetLanguage("test")
 	SetGlobalLocalizationManager(mgr)
+	defer SetGlobalLocalizationManager(nil)
 	out := captureBannerOutput(func() { PrintRainbowBannerWithDelay(0) })
 	if !strings.Contains(out, "Hola") || !strings.Contains(out, "Mundo") {
 		t.Errorf("expected localized messages in banner output: %s", out)

--- a/ui/banner_localization_bdd_test.go
+++ b/ui/banner_localization_bdd_test.go
@@ -1,0 +1,54 @@
+package ui
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"please/localization"
+)
+
+func TestWhenPrintingInstallationSuccessWithLocalization_ShouldUseLocalizedMessages(t *testing.T) {
+	dir := t.TempDir()
+	langPath := dir + "/lang.json"
+	os.WriteFile(langPath, []byte(`{"language":"x","theme":"default","messages":{"installation":{"success":"OK","try_it":"TRY","magic":"MAGIC"}}}`), 0644)
+	mgr, err := localization.NewLocalizationManager(dir)
+	if err != nil {
+		t.Fatalf("manager error: %v", err)
+	}
+	mgr.LoadLanguage("x", langPath)
+	mgr.SetLanguage("x")
+	SetGlobalLocalizationManager(mgr)
+	defer SetGlobalLocalizationManager(nil)
+
+	output := captureStdout(func() { PrintInstallationSuccess() })
+	if !strings.Contains(output, "OK") || !strings.Contains(output, "TRY") || !strings.Contains(output, "MAGIC") {
+		t.Errorf("expected localized messages, got: %s", output)
+	}
+}
+
+func TestWhenPrintingFooterWithLocalization_ShouldUseLocalizedMessages(t *testing.T) {
+	dir := t.TempDir()
+	langPath := dir + "/lang.json"
+	os.WriteFile(langPath, []byte(`{"language":"x","theme":"default","messages":{"footer":{"tips":"TIPS","happy":"HAPPY"}}}`), 0644)
+	mgr, err := localization.NewLocalizationManager(dir)
+	if err != nil {
+		t.Fatalf("manager error: %v", err)
+	}
+	mgr.LoadLanguage("x", langPath)
+	mgr.SetLanguage("x")
+	SetGlobalLocalizationManager(mgr)
+
+	defer SetGlobalLocalizationManager(nil)
+	output := captureStdout(func() { PrintFooter() })
+	if !strings.Contains(output, "TIPS") || !strings.Contains(output, "HAPPY") {
+		t.Errorf("expected localized footer messages, got: %s", output)
+	}
+}
+
+func TestWhenPrintingRainbowBanner_ShouldIncludeAsciiArtLines(t *testing.T) {
+	output := captureStdout(func() { PrintRainbowBannerWithDelay(0) })
+	if strings.Count(output, "\n") < 6 {
+		t.Errorf("expected at least 6 lines in banner, got %d", strings.Count(output, "\n"))
+	}
+}

--- a/ui/banner_test.go
+++ b/ui/banner_test.go
@@ -109,6 +109,7 @@ func TestWhenSettingLocalizationManager_ShouldStoreManager(t *testing.T) {
 		t.Fatalf("manager init: %v", err)
 	}
 	SetGlobalLocalizationManager(mgr)
+	defer SetGlobalLocalizationManager(nil)
 	// Test that the function can be called without error
 	// We can't easily test the internal state without exposing it
 }
@@ -126,6 +127,7 @@ func TestWhenBannerUsesLocalization_ShouldDisplayTitleAndSubtitle(t *testing.T) 
 	mgr.LoadLanguage("en-test", langPath)
 	mgr.SetLanguage("en-test")
 	SetGlobalLocalizationManager(mgr)
+	defer SetGlobalLocalizationManager(nil)
 	output := captureStdout(func() { PrintRainbowBannerWithDelay(0) })
 	if !strings.Contains(output, "Hello") || !strings.Contains(output, "World") {
 		t.Errorf("expected localized title and subtitle, got: %s", output)

--- a/ui/colors_additional_bdd_test.go
+++ b/ui/colors_additional_bdd_test.go
@@ -1,0 +1,10 @@
+package ui
+
+import "testing"
+
+func TestWhenCountingRainbowColors_ShouldEqualSeven(t *testing.T) {
+	colors := []string{Rainbow1, Rainbow2, Rainbow3, Rainbow4, Rainbow5, Rainbow6, Rainbow7}
+	if len(colors) != 7 {
+		t.Errorf("expected 7 rainbow colors, got %d", len(colors))
+	}
+}

--- a/ui/help_bdd_test.go
+++ b/ui/help_bdd_test.go
@@ -23,6 +23,7 @@ func TestWhenShowingHelpWithLocalization_ShouldUseLocalizedBannerTexts(t *testin
 	mgr.LoadLanguage("x", langPath)
 	mgr.SetLanguage("x")
 	SetGlobalLocalizationManager(mgr)
+	defer SetGlobalLocalizationManager(nil)
 	out := captureHelpOutput(ShowHelp)
 	if !strings.Contains(out, "Hola") || !strings.Contains(out, "Ayuda") {
 		t.Errorf("expected localized banner text: %s", out)

--- a/ui/help_version_bdd_test.go
+++ b/ui/help_version_bdd_test.go
@@ -1,0 +1,14 @@
+package ui
+
+import (
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestWhenShowingVersion_ShouldIncludeRuntimeDetails(t *testing.T) {
+	output := captureStdoutForHelp(ShowVersion)
+	if !strings.Contains(output, runtime.GOOS) || !strings.Contains(output, runtime.GOARCH) || !strings.Contains(output, runtime.Version()) {
+		t.Errorf("expected runtime details in version output: %s", output)
+	}
+}

--- a/ui/progress_additional_bdd_test.go
+++ b/ui/progress_additional_bdd_test.go
@@ -1,0 +1,45 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"please/types"
+)
+
+func TestWhenCreatingProgressIndicator_ShouldInitializeFields(t *testing.T) {
+	p := NewProgressIndicator("test")
+	if p.message != "test" || p.isRunning {
+		t.Errorf("progress indicator not initialized correctly: %+v", p)
+	}
+}
+
+func TestWhenUpdatingProgressMessage_ShouldChangeInternalMessage(t *testing.T) {
+	p := NewProgressIndicator("one")
+	p.UpdateStatus("two")
+	if p.message != "two" {
+		t.Errorf("expected message 'two', got %s", p.message)
+	}
+}
+
+func TestWhenStartingAndStoppingProgress_ShouldToggleRunningState(t *testing.T) {
+	p := NewProgressIndicator("msg")
+	p.Start()
+	if !p.isRunning {
+		t.Error("expected indicator running")
+	}
+	p.Stop()
+	if p.isRunning {
+		t.Error("expected indicator stopped")
+	}
+}
+func TestWhenGettingScriptGenerationMessagesForOllama_ShouldIncludeStartupSteps(t *testing.T) {
+	cfg := &types.Config{Provider: "ollama", PreferredModel: "test"}
+	msgs := GetScriptGenerationProgressMessages(cfg)
+	if len(msgs) < 7 {
+		t.Errorf("expected extra startup messages for ollama, got %d", len(msgs))
+	}
+	if !strings.Contains(msgs[0], "Ollama") {
+		t.Errorf("expected first message to mention Ollama startup")
+	}
+}


### PR DESCRIPTION
## Summary
- add localization banner BDD tests
- add version output BDD test
- test progress indicator lifecycle
- verify rainbow color count
- support script display and menu message retrieval
- parse --language/--theme flags before command handling
- update localization tests for cleanup

## Testing
- `PROGRESS_TEST_MODE=1 go test ./...`
- `PROGRESS_TEST_MODE=1 go test ./ui -cover`


------
https://chatgpt.com/codex/tasks/task_e_684d79b5032083219913aca3293d043a