### PR TITLE
Implement C# Result pattern foundation

### DIFF
--- a/Please.sln
+++ b/Please.sln
@@ -35,6 +35,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Application.IntegrationTest
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Please.Application.IntegrationTests", "tests\Application.IntegrationTests\Please.Application.IntegrationTests\Please.Application.IntegrationTests.csproj", "{196F9146-25E5-49C7-8D38-FA94ED59898A}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Please.UnitTests", "tests\Please.UnitTests\Please.UnitTests.csproj", "{E6E77AAF-24D4-465A-98A0-2BA6E2796E7C}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -129,6 +131,18 @@ Global
 		{196F9146-25E5-49C7-8D38-FA94ED59898A}.Release|x64.Build.0 = Release|Any CPU
 		{196F9146-25E5-49C7-8D38-FA94ED59898A}.Release|x86.ActiveCfg = Release|Any CPU
 		{196F9146-25E5-49C7-8D38-FA94ED59898A}.Release|x86.Build.0 = Release|Any CPU
+		{E6E77AAF-24D4-465A-98A0-2BA6E2796E7C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E6E77AAF-24D4-465A-98A0-2BA6E2796E7C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E6E77AAF-24D4-465A-98A0-2BA6E2796E7C}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{E6E77AAF-24D4-465A-98A0-2BA6E2796E7C}.Debug|x64.Build.0 = Debug|Any CPU
+		{E6E77AAF-24D4-465A-98A0-2BA6E2796E7C}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{E6E77AAF-24D4-465A-98A0-2BA6E2796E7C}.Debug|x86.Build.0 = Debug|Any CPU
+		{E6E77AAF-24D4-465A-98A0-2BA6E2796E7C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E6E77AAF-24D4-465A-98A0-2BA6E2796E7C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E6E77AAF-24D4-465A-98A0-2BA6E2796E7C}.Release|x64.ActiveCfg = Release|Any CPU
+		{E6E77AAF-24D4-465A-98A0-2BA6E2796E7C}.Release|x64.Build.0 = Release|Any CPU
+		{E6E77AAF-24D4-465A-98A0-2BA6E2796E7C}.Release|x86.ActiveCfg = Release|Any CPU
+		{E6E77AAF-24D4-465A-98A0-2BA6E2796E7C}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -148,5 +162,6 @@ Global
 		{85E60548-4DF9-462B-9F1B-39CF383DCB55} = {B7A67187-1738-495E-17CB-A690C572E7D4}
 		{EFBC886A-A897-E26D-6F34-4F7FB16D268C} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
 		{196F9146-25E5-49C7-8D38-FA94ED59898A} = {EFBC886A-A897-E26D-6F34-4F7FB16D268C}
+		{E6E77AAF-24D4-465A-98A0-2BA6E2796E7C} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
 	EndGlobalSection
 EndGlobal

--- a/src/Please/Application/Services/IScriptService.cs
+++ b/src/Please/Application/Services/IScriptService.cs
@@ -1,0 +1,19 @@
+using Please.Domain.Common;
+using Please.Domain.Entities;
+
+namespace Please.Application.Services;
+
+public interface IScriptService
+{
+    Task<Result<ScriptResponse>> GenerateScriptAsync(
+        ScriptRequest request,
+        CancellationToken cancellationToken = default);
+
+    Task<Result<ScriptResponse>> GetScriptAsync(
+        ScriptId id,
+        CancellationToken cancellationToken = default);
+
+    Task<Result<IEnumerable<ScriptResponse>>> GetRecentScriptsAsync(
+        int count = 10,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Please/Application/Services/ScriptService.cs
+++ b/src/Please/Application/Services/ScriptService.cs
@@ -1,0 +1,46 @@
+using Please.Domain.Common;
+using Please.Domain.Entities;
+using Please.Domain.Interfaces;
+
+namespace Please.Application.Services;
+
+public sealed class ScriptService : IScriptService
+{
+    private readonly IScriptGenerator _generator;
+    private readonly IScriptRepository _repository;
+
+    public ScriptService(IScriptGenerator generator, IScriptRepository repository)
+    {
+        _generator = generator;
+        _repository = repository;
+    }
+
+    public async Task<Result<ScriptResponse>> GenerateScriptAsync(
+        ScriptRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        var generationResult = await _generator.GenerateScriptAsync(request, cancellationToken);
+        if (generationResult.IsFailure)
+            return Result<ScriptResponse>.Failure(generationResult.Error);
+
+        var saveResult = await _repository.SaveScriptAsync(generationResult.Value!, cancellationToken);
+        if (saveResult.IsFailure)
+            return Result<ScriptResponse>.Failure($"Failed to save script: {saveResult.Error}");
+
+        return Result<ScriptResponse>.Success(generationResult.Value!);
+    }
+
+    public async Task<Result<ScriptResponse>> GetScriptAsync(
+        ScriptId id,
+        CancellationToken cancellationToken = default)
+    {
+        return await _repository.GetLastScriptAsync(cancellationToken);
+    }
+
+    public Task<Result<IEnumerable<ScriptResponse>>> GetRecentScriptsAsync(
+        int count = 10,
+        CancellationToken cancellationToken = default)
+    {
+        return _repository.GetScriptHistoryAsync(count, null, cancellationToken);
+    }
+}

--- a/src/Please/Domain/Common/Result.cs
+++ b/src/Please/Domain/Common/Result.cs
@@ -1,0 +1,58 @@
+namespace Please.Domain.Common;
+
+public abstract record Result
+{
+    public bool IsSuccess { get; init; }
+    public bool IsFailure => !IsSuccess;
+    public string Error { get; init; } = string.Empty;
+
+    public static Result Success() => new SuccessResult();
+    public static Result Failure(string error) => new FailureResult(error);
+
+    protected Result() { }
+}
+
+public sealed record SuccessResult : Result
+{
+    public SuccessResult() { IsSuccess = true; }
+}
+
+public sealed record FailureResult : Result
+{
+    public FailureResult(string error)
+    {
+        IsSuccess = false;
+        Error = error;
+    }
+}
+
+public sealed record Result<T> : Result
+{
+    public T? Value { get; init; }
+
+    public static Result<T> Success(T value) => new()
+    {
+        IsSuccess = true,
+        Value = value
+    };
+
+    public static Result<T> Failure(string error) => new()
+    {
+        IsSuccess = false,
+        Error = error
+    };
+
+    public Result<TNext> Map<TNext>(Func<T, TNext> map)
+    {
+        return IsSuccess
+            ? Result<TNext>.Success(map(Value!))
+            : Result<TNext>.Failure(Error);
+    }
+
+    public async Task<Result<TNext>> MapAsync<TNext>(Func<T, Task<TNext>> map)
+    {
+        return IsSuccess
+            ? Result<TNext>.Success(await map(Value!))
+            : Result<TNext>.Failure(Error);
+    }
+}

--- a/src/Please/Domain/Common/StronglyTypedId.cs
+++ b/src/Please/Domain/Common/StronglyTypedId.cs
@@ -1,0 +1,9 @@
+namespace Please.Domain.Common;
+
+public abstract record StronglyTypedId<T>(T Value)
+    where T : IComparable<T>, IEquatable<T>
+{
+    public override string ToString() => Value?.ToString() ?? string.Empty;
+
+    public static implicit operator T(StronglyTypedId<T> id) => id.Value;
+}

--- a/src/Please/Domain/Entities/ScriptId.cs
+++ b/src/Please/Domain/Entities/ScriptId.cs
@@ -1,0 +1,10 @@
+using Please.Domain.Common;
+
+namespace Please.Domain.Entities;
+
+public sealed record ScriptId(Guid Value) : StronglyTypedId<Guid>(Value)
+{
+    public static ScriptId New() => new(Guid.NewGuid());
+    public static ScriptId From(string value) => new(Guid.Parse(value));
+    public static ScriptId Empty => new(Guid.Empty);
+}

--- a/src/Please/Domain/Entities/ScriptRequest.cs
+++ b/src/Please/Domain/Entities/ScriptRequest.cs
@@ -1,0 +1,32 @@
+using Please.Domain.Enums;
+using Please.Domain.Common;
+
+namespace Please.Domain.Entities;
+
+public sealed record ScriptRequest
+{
+    public string TaskDescription { get; init; } = string.Empty;
+    public ProviderType? Provider { get; init; }
+    public string? Model { get; init; }
+    public ScriptType ScriptType { get; init; } = ScriptType.Bash;
+    public DateTime RequestTime { get; init; } = DateTime.UtcNow;
+    public string? WorkingDirectory { get; init; }
+    public bool ForceExecution { get; init; }
+
+    public static Result<ScriptRequest> Create(string taskDescription,
+        ProviderType? provider = null,
+        string? model = null,
+        ScriptType scriptType = ScriptType.Bash)
+    {
+        if (string.IsNullOrWhiteSpace(taskDescription))
+            return Result<ScriptRequest>.Failure("Task description cannot be empty");
+
+        return Result<ScriptRequest>.Success(new ScriptRequest
+        {
+            TaskDescription = taskDescription.Trim(),
+            Provider = provider,
+            Model = model,
+            ScriptType = scriptType
+        });
+    }
+}

--- a/src/Please/Domain/Entities/ScriptResponse.cs
+++ b/src/Please/Domain/Entities/ScriptResponse.cs
@@ -1,0 +1,67 @@
+using Please.Domain.Common;
+using Please.Domain.Enums;
+
+namespace Please.Domain.Entities;
+
+public sealed class ScriptResponse
+{
+    public ScriptId Id { get; private set; } = ScriptId.Empty;
+    public string Script { get; private set; } = string.Empty;
+    public string TaskDescription { get; private set; } = string.Empty;
+    public ProviderType Provider { get; private set; }
+    public string Model { get; private set; } = string.Empty;
+    public ScriptType ScriptType { get; private set; }
+    public RiskLevel RiskLevel { get; private set; }
+    public List<string> Warnings { get; private set; } = new();
+    public List<string> SafetyNotes { get; private set; } = new();
+    public DateTime CreatedAt { get; private set; }
+
+    private ScriptResponse() { }
+
+    public static Result<ScriptResponse> Create(
+        string script,
+        string taskDescription,
+        ProviderType provider,
+        string model,
+        ScriptType scriptType = ScriptType.Bash,
+        RiskLevel riskLevel = RiskLevel.Low)
+    {
+        if (string.IsNullOrWhiteSpace(script))
+            return Result<ScriptResponse>.Failure("Script content cannot be empty");
+        if (string.IsNullOrWhiteSpace(taskDescription))
+            return Result<ScriptResponse>.Failure("Task description cannot be empty");
+        if (string.IsNullOrWhiteSpace(model))
+            return Result<ScriptResponse>.Failure("Model cannot be empty");
+
+        return Result<ScriptResponse>.Success(new ScriptResponse
+        {
+            Id = ScriptId.New(),
+            Script = script.Trim(),
+            TaskDescription = taskDescription.Trim(),
+            Provider = provider,
+            Model = model.Trim(),
+            ScriptType = scriptType,
+            RiskLevel = riskLevel,
+            CreatedAt = DateTime.UtcNow
+        });
+    }
+
+    public ScriptResponse WithWarning(string warning)
+    {
+        if (!string.IsNullOrWhiteSpace(warning))
+            Warnings.Add(warning);
+        return this;
+    }
+
+    public ScriptResponse WithSafetyNote(string note)
+    {
+        if (!string.IsNullOrWhiteSpace(note))
+            SafetyNotes.Add(note);
+        return this;
+    }
+
+    public bool RequiresConfirmation =>
+        RiskLevel >= RiskLevel.Medium || Warnings.Any();
+
+    public bool IsDangerous => RiskLevel == RiskLevel.High;
+}

--- a/src/Please/Domain/Enums/ProviderType.cs
+++ b/src/Please/Domain/Enums/ProviderType.cs
@@ -1,0 +1,11 @@
+namespace Please.Domain.Enums;
+
+/// <summary>
+/// AI providers supported by the application
+/// </summary>
+public enum ProviderType
+{
+    OpenAI,
+    Anthropic,
+    Ollama
+}

--- a/src/Please/Domain/Enums/RiskLevel.cs
+++ b/src/Please/Domain/Enums/RiskLevel.cs
@@ -1,0 +1,12 @@
+namespace Please.Domain.Enums;
+
+/// <summary>
+/// Risk assessment levels for script execution
+/// </summary>
+public enum RiskLevel
+{
+    Low,
+    Medium,
+    High,
+    Critical
+}

--- a/src/Please/Domain/Enums/ScriptType.cs
+++ b/src/Please/Domain/Enums/ScriptType.cs
@@ -1,0 +1,13 @@
+namespace Please.Domain.Enums;
+
+/// <summary>
+/// Types of scripts that can be generated
+/// </summary>
+public enum ScriptType
+{
+    PowerShell,
+    Bash,
+    Command,
+    Python,
+    Auto // Let the AI decide based on OS/context
+}

--- a/src/Please/Domain/Interfaces/IScriptGenerator.cs
+++ b/src/Please/Domain/Interfaces/IScriptGenerator.cs
@@ -1,0 +1,27 @@
+using Please.Domain.Common;
+using Please.Domain.Entities;
+
+namespace Please.Domain.Interfaces;
+
+/// <summary>
+/// Contract for AI-powered script generation
+/// </summary>
+public interface IScriptGenerator
+{
+    /// <summary>
+    /// Generates a script based on the provided request
+    /// </summary>
+    Task<Result<ScriptResponse>> GenerateScriptAsync(
+        ScriptRequest request,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Validates if the provider and model combination is supported
+    /// </summary>
+    Task<bool> IsProviderAvailableAsync(ScriptRequest request, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets the fallback model for a specific provider if the requested model is unavailable
+    /// </summary>
+    string GetFallbackModel(ScriptRequest request);
+}

--- a/src/Please/Domain/Interfaces/IScriptRepository.cs
+++ b/src/Please/Domain/Interfaces/IScriptRepository.cs
@@ -1,0 +1,38 @@
+using Please.Domain.Common;
+using Please.Domain.Entities;
+
+namespace Please.Domain.Interfaces;
+
+/// <summary>
+/// Contract for script persistence and retrieval
+/// </summary>
+public interface IScriptRepository
+{
+    /// <summary>
+    /// Saves a script response to history
+    /// </summary>
+    Task<Result> SaveScriptAsync(ScriptResponse response, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Retrieves the last generated script
+    /// </summary>
+    Task<Result<ScriptResponse>> GetLastScriptAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Retrieves script history with optional filtering
+    /// </summary>
+    Task<Result<IEnumerable<ScriptResponse>>> GetScriptHistoryAsync(
+        int? count = null,
+        DateTime? since = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Clears script history
+    /// </summary>
+    Task<Result> ClearHistoryAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Checks if any scripts exist in history
+    /// </summary>
+    Task<bool> HasHistoryAsync(CancellationToken cancellationToken = default);
+}

--- a/src/Please/Please.csproj
+++ b/src/Please/Please.csproj
@@ -1,0 +1,15 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>Please</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="System.Text.Json" Version="8.0.0" />
+  </ItemGroup>
+
+</Project>

--- a/src/Please/Program.cs
+++ b/src/Please/Program.cs
@@ -1,0 +1,4 @@
+using Please.Application.Services;
+
+// Placeholder entry point for single executable
+Console.WriteLine("Please CLI (under development)");

--- a/tests/Please.UnitTests/GlobalUsings.cs
+++ b/tests/Please.UnitTests/GlobalUsings.cs
@@ -1,0 +1,1 @@
+global using NUnit.Framework;

--- a/tests/Please.UnitTests/Please.UnitTests.csproj
+++ b/tests/Please.UnitTests/Please.UnitTests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../src/Please/Please.csproj" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
+    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
+    <PackageReference Include="NUnit.Analyzers" Version="3.6.1" />
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Please.UnitTests/ResultTests.cs
+++ b/tests/Please.UnitTests/ResultTests.cs
@@ -1,0 +1,24 @@
+using NUnit.Framework;
+using Please.Domain.Common;
+
+namespace Please.UnitTests;
+
+[TestFixture]
+public class ResultTests
+{
+    [Test]
+    public void Test_result_success_contains_value()
+    {
+        var result = Result<string>.Success("ok");
+        Assert.That(result.IsSuccess, Is.True);
+        Assert.That(result.Value, Is.EqualTo("ok"));
+    }
+
+    [Test]
+    public void Test_result_failure_contains_error_message()
+    {
+        var result = Result<int>.Failure("fail");
+        Assert.That(result.IsFailure, Is.True);
+        Assert.That(result.Error, Is.EqualTo("fail"));
+    }
+}

--- a/tests/Please.UnitTests/ScriptResponseTests.cs
+++ b/tests/Please.UnitTests/ScriptResponseTests.cs
@@ -1,0 +1,34 @@
+using NUnit.Framework;
+using Please.Domain.Entities;
+using Please.Domain.Enums;
+
+namespace Please.UnitTests;
+
+[TestFixture]
+public class ScriptResponseTests
+{
+    [Test]
+    public void Test_script_response_with_valid_data_creates_successfully()
+    {
+        var result = ScriptResponse.Create(
+            "echo hi",
+            "Say hi",
+            ProviderType.OpenAI,
+            "gpt-4");
+
+        Assert.That(result.IsSuccess, Is.True);
+        Assert.That(result.Value!.Script, Is.EqualTo("echo hi"));
+    }
+
+    [Test]
+    public void Test_invalid_input_returns_failure_result()
+    {
+        var result = ScriptResponse.Create(
+            "",
+            "",
+            ProviderType.OpenAI,
+            "");
+
+        Assert.That(result.IsFailure, Is.True);
+    }
+}

--- a/tests/Please.UnitTests/StronglyTypedIdTests.cs
+++ b/tests/Please.UnitTests/StronglyTypedIdTests.cs
@@ -1,0 +1,25 @@
+using NUnit.Framework;
+using Please.Domain.Entities;
+
+namespace Please.UnitTests;
+
+[TestFixture]
+public class StronglyTypedIdTests
+{
+    [Test]
+    public void Test_script_id_generates_unique_guid()
+    {
+        var id1 = ScriptId.New();
+        var id2 = ScriptId.New();
+        Assert.That(id1, Is.Not.EqualTo(id2));
+    }
+
+    [Test]
+    public void Test_script_id_converts_to_underlying_value()
+    {
+        var guid = Guid.NewGuid();
+        ScriptId id = new(guid);
+        Guid value = id;
+        Assert.That(value, Is.EqualTo(guid));
+    }
+}


### PR DESCRIPTION
## Summary
- start single-project `src/Please` with Result pattern and strongly typed IDs
- add ScriptService and domain entities using the new pattern
- create NUnit tests covering Result, ScriptId and ScriptResponse
- include new test project in solution

## Testing
- `dotnet test Please.sln -v minimal`
- `dotnet test tests/Please.UnitTests/Please.UnitTests.csproj --collect:"XPlat Code Coverage"` *(fails to reach 85% coverage)*

------
https://chatgpt.com/codex/tasks/task_e_684eb9e5d4808321a6239ab0582ee26e