### PR TITLE
Ensure Go build and tests pass

### DIFF
--- a/legacy/go.mod
+++ b/legacy/go.mod
@@ -1,3 +1,7 @@
 module please
 
 go 1.24.4
+
+replace please/ui => ../ui
+
+require please/ui v0.0.0

--- a/legacy/localization/manager.go
+++ b/legacy/localization/manager.go
@@ -28,6 +28,10 @@ func NewLocalizationManager(configDir string) (*LocalizationManager, error) {
 		mgr.config.Messages = cfg.Messages
 		mgr.config.Themes = cfg.Themes
 		mgr.fallback = cfg
+	} else if cfg, err := LoadFromFile(filepath.Join(configDir, "..", "themes", "en-us.json")); err == nil {
+		mgr.config.Messages = cfg.Messages
+		mgr.config.Themes = cfg.Themes
+		mgr.fallback = cfg
 	} else {
 		mgr.fallback = mgr.config
 		mgr.config.Themes = types.Theme{Colors: map[string]string{"primary": "#00ff41"}}

--- a/ui/go.mod
+++ b/ui/go.mod
@@ -1,0 +1,3 @@
+module please/ui
+
+go 1.24.4


### PR DESCRIPTION
## Summary
- create Go module for the UI package
- update legacy `go.mod` to reference UI module
- allow fallback theme lookup in `NewLocalizationManager`

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68565673c17c83218a1fb8d42e019df8