### PR TITLE
Add result pattern and strongly typed IDs

### DIFF
--- a/src/Domain/Please.Domain/Common/Result.cs
+++ b/src/Domain/Please.Domain/Common/Result.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Threading.Tasks;
+namespace Please.Domain.Common;
+
+public abstract record Result
+{
+    public bool IsSuccess { get; init; }
+    public bool IsFailure => !IsSuccess;
+    public string Error { get; init; } = string.Empty;
+
+    public static Result Success() => new SuccessResult();
+    public static Result Failure(string error) => new FailureResult(error);
+
+    protected Result() { }
+}
+
+public sealed record SuccessResult : Result
+{
+    public SuccessResult()
+    {
+        IsSuccess = true;
+    }
+}
+
+public sealed record FailureResult : Result
+{
+    public FailureResult(string error)
+    {
+        IsSuccess = false;
+        Error = error;
+    }
+}
+
+public sealed record Result<T> : Result
+{
+    public T? Value { get; init; }
+
+    public static Result<T> Success(T value) => new()
+    {
+        IsSuccess = true,
+        Value = value
+    };
+
+    public static Result<T> Failure(string error) => new()
+    {
+        IsSuccess = false,
+        Error = error
+    };
+
+    public Result<TNext> Map<TNext>(Func<T, TNext> map)
+    {
+        return IsSuccess
+            ? Result<TNext>.Success(map(Value!))
+            : Result<TNext>.Failure(Error);
+    }
+
+    public async Task<Result<TNext>> MapAsync<TNext>(Func<T, Task<TNext>> map)
+    {
+        return IsSuccess
+            ? Result<TNext>.Success(await map(Value!))
+            : Result<TNext>.Failure(Error);
+    }
+}

--- a/src/Domain/Please.Domain/Common/StronglyTypedId.cs
+++ b/src/Domain/Please.Domain/Common/StronglyTypedId.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace Please.Domain.Common;
+
+public abstract record StronglyTypedId<T>(T Value)
+    where T : IComparable<T>, IEquatable<T>
+{
+    public sealed override string ToString() => Value?.ToString() ?? string.Empty;
+
+    public static implicit operator T(StronglyTypedId<T> id) => id.Value;
+}

--- a/src/Domain/Please.Domain/Entities/ProviderId.cs
+++ b/src/Domain/Please.Domain/Entities/ProviderId.cs
@@ -1,0 +1,10 @@
+using Please.Domain.Common;
+
+namespace Please.Domain.Entities;
+
+public sealed record ProviderId(string Value) : StronglyTypedId<string>(Value)
+{
+    public static ProviderId OpenAI => new("openai");
+    public static ProviderId Anthropic => new("anthropic");
+    public static ProviderId Ollama => new("ollama");
+}

--- a/src/Domain/Please.Domain/Entities/ScriptId.cs
+++ b/src/Domain/Please.Domain/Entities/ScriptId.cs
@@ -1,0 +1,10 @@
+using Please.Domain.Common;
+
+namespace Please.Domain.Entities;
+
+public sealed record ScriptId(Guid Value) : StronglyTypedId<Guid>(Value)
+{
+    public static ScriptId New() => new(Guid.NewGuid());
+    public static ScriptId From(string value) => new(Guid.Parse(value));
+    public static ScriptId Empty => new(Guid.Empty);
+}

--- a/tests/Domain.UnitTests/Please.Domain.UnitTests/Common/ResultTests.cs
+++ b/tests/Domain.UnitTests/Please.Domain.UnitTests/Common/ResultTests.cs
@@ -8,7 +8,7 @@ namespace Please.Domain.UnitTests.Common;
 public class ResultTests
 {
     [Test]
-    public void Test_success_result_indicates_success()
+    public void a_success_result_indicates_success()
     {
         var result = Result.Success();
         Assert.That(result.IsSuccess, Is.True);
@@ -16,7 +16,7 @@ public class ResultTests
     }
 
     [Test]
-    public void Test_failure_result_contains_error_message()
+    public void a_failure_result_contains_the_error_message()
     {
         const string error = "something went wrong";
         var result = Result.Failure(error);
@@ -25,7 +25,7 @@ public class ResultTests
     }
 
     [Test]
-    public void Test_generic_success_holds_value()
+    public void a_generic_success_holds_the_value()
     {
         var result = Result<int>.Success(42);
         Assert.That(result.Value, Is.EqualTo(42));
@@ -33,7 +33,7 @@ public class ResultTests
     }
 
     [Test]
-    public void Test_map_transforms_value_when_success()
+    public void mapping_transforms_the_value_when_successful()
     {
         var start = Result<int>.Success(2);
         var mapped = start.Map(x => x * 2);
@@ -42,7 +42,7 @@ public class ResultTests
     }
 
     [Test]
-    public void Test_map_preserves_error_when_failure()
+    public void mapping_preserves_the_error_when_failure()
     {
         var start = Result<int>.Failure("bad");
         var mapped = start.Map(x => x * 2);
@@ -51,7 +51,7 @@ public class ResultTests
     }
 
     [Test]
-    public async Task Test_map_async_transforms_value_when_success()
+    public async Task mapping_async_transforms_the_value_when_successful()
     {
         var start = Result<int>.Success(3);
         var mapped = await start.MapAsync(x => Task.FromResult(x + 2));

--- a/tests/Domain.UnitTests/Please.Domain.UnitTests/Common/ResultTests.cs
+++ b/tests/Domain.UnitTests/Please.Domain.UnitTests/Common/ResultTests.cs
@@ -1,0 +1,61 @@
+using NUnit.Framework;
+using System.Threading.Tasks;
+using Please.Domain.Common;
+
+namespace Please.Domain.UnitTests.Common;
+
+[TestFixture]
+public class ResultTests
+{
+    [Test]
+    public void Test_success_result_indicates_success()
+    {
+        var result = Result.Success();
+        Assert.That(result.IsSuccess, Is.True);
+        Assert.That(result.IsFailure, Is.False);
+    }
+
+    [Test]
+    public void Test_failure_result_contains_error_message()
+    {
+        const string error = "something went wrong";
+        var result = Result.Failure(error);
+        Assert.That(result.IsFailure, Is.True);
+        Assert.That(result.Error, Is.EqualTo(error));
+    }
+
+    [Test]
+    public void Test_generic_success_holds_value()
+    {
+        var result = Result<int>.Success(42);
+        Assert.That(result.Value, Is.EqualTo(42));
+        Assert.That(result.IsSuccess, Is.True);
+    }
+
+    [Test]
+    public void Test_map_transforms_value_when_success()
+    {
+        var start = Result<int>.Success(2);
+        var mapped = start.Map(x => x * 2);
+        Assert.That(mapped.IsSuccess, Is.True);
+        Assert.That(mapped.Value, Is.EqualTo(4));
+    }
+
+    [Test]
+    public void Test_map_preserves_error_when_failure()
+    {
+        var start = Result<int>.Failure("bad");
+        var mapped = start.Map(x => x * 2);
+        Assert.That(mapped.IsFailure, Is.True);
+        Assert.That(mapped.Error, Is.EqualTo("bad"));
+    }
+
+    [Test]
+    public async Task Test_map_async_transforms_value_when_success()
+    {
+        var start = Result<int>.Success(3);
+        var mapped = await start.MapAsync(x => Task.FromResult(x + 2));
+        Assert.That(mapped.IsSuccess, Is.True);
+        Assert.That(mapped.Value, Is.EqualTo(5));
+    }
+}

--- a/tests/Domain.UnitTests/Please.Domain.UnitTests/Common/StronglyTypedIdTests.cs
+++ b/tests/Domain.UnitTests/Please.Domain.UnitTests/Common/StronglyTypedIdTests.cs
@@ -1,0 +1,36 @@
+using System;
+using NUnit.Framework;
+using Please.Domain.Common;
+using Please.Domain.Entities;
+
+namespace Please.Domain.UnitTests.Common;
+
+[TestFixture]
+public class StronglyTypedIdTests
+{
+    [Test]
+    public void Test_strongly_typed_id_converts_to_underlying_value()
+    {
+        var id = ScriptId.From("00000000-0000-0000-0000-000000000001");
+        Guid value = id;
+        Assert.That(value, Is.EqualTo(Guid.Parse("00000000-0000-0000-0000-000000000001")));
+        Assert.That(id.ToString(), Is.EqualTo("00000000-0000-0000-0000-000000000001"));
+    }
+
+    [Test]
+    public void Test_script_id_new_creates_unique_identifier()
+    {
+        var id1 = ScriptId.New();
+        var id2 = ScriptId.New();
+        Assert.That(id1.Value, Is.Not.EqualTo(Guid.Empty));
+        Assert.That(id2.Value, Is.Not.EqualTo(id1.Value));
+    }
+
+    [Test]
+    public void Test_provider_id_static_values_are_expected()
+    {
+        Assert.That(ProviderId.OpenAI.Value, Is.EqualTo("openai"));
+        Assert.That(ProviderId.Anthropic.Value, Is.EqualTo("anthropic"));
+        Assert.That(ProviderId.Ollama.Value, Is.EqualTo("ollama"));
+    }
+}

--- a/tests/Domain.UnitTests/Please.Domain.UnitTests/Common/StronglyTypedIdTests.cs
+++ b/tests/Domain.UnitTests/Please.Domain.UnitTests/Common/StronglyTypedIdTests.cs
@@ -9,7 +9,7 @@ namespace Please.Domain.UnitTests.Common;
 public class StronglyTypedIdTests
 {
     [Test]
-    public void Test_strongly_typed_id_converts_to_underlying_value()
+    public void a_strongly_typed_id_converts_to_the_underlying_value()
     {
         var id = ScriptId.From("00000000-0000-0000-0000-000000000001");
         Guid value = id;
@@ -18,7 +18,7 @@ public class StronglyTypedIdTests
     }
 
     [Test]
-    public void Test_script_id_new_creates_unique_identifier()
+    public void script_id_new_creates_a_unique_identifier()
     {
         var id1 = ScriptId.New();
         var id2 = ScriptId.New();
@@ -27,7 +27,7 @@ public class StronglyTypedIdTests
     }
 
     [Test]
-    public void Test_provider_id_static_values_are_expected()
+    public void provider_id_static_values_are_as_expected()
     {
         Assert.That(ProviderId.OpenAI.Value, Is.EqualTo("openai"));
         Assert.That(ProviderId.Anthropic.Value, Is.EqualTo("anthropic"));

--- a/tests/Domain.UnitTests/Please.Domain.UnitTests/Exceptions/DomainExceptionTests.cs
+++ b/tests/Domain.UnitTests/Please.Domain.UnitTests/Exceptions/DomainExceptionTests.cs
@@ -7,28 +7,28 @@ namespace Please.Domain.UnitTests.Exceptions;
 public class DomainExceptionTests
 {
     [Test]
-    public void Test_unsupported_provider_message_contains_provider()
+    public void unsupported_provider_message_contains_the_provider()
     {
         var ex = new UnsupportedProviderException("foo");
         Assert.That(ex.Message, Is.EqualTo("Unsupported provider: foo"));
     }
 
     [Test]
-    public void Test_unsupported_model_message_references_provider_and_model()
+    public void unsupported_model_message_references_the_provider_and_model()
     {
         var ex = new UnsupportedModelException("p", "m");
         Assert.That(ex.Message, Is.EqualTo("Model 'm' is not supported by provider 'p'"));
     }
 
     [Test]
-    public void Test_script_generation_exception_preserves_message()
+    public void script_generation_exception_preserves_the_message()
     {
         var ex = new ScriptGenerationException("msg");
         Assert.That(ex.Message, Is.EqualTo("msg"));
     }
 
     [Test]
-    public void Test_script_validation_exception_preserves_message()
+    public void script_validation_exception_preserves_the_message()
     {
         var ex = new ScriptValidationException("oops");
         Assert.That(ex.Message, Is.EqualTo("oops"));

--- a/tests/Domain.UnitTests/Please.Domain.UnitTests/Exceptions/DomainExceptionTests.cs
+++ b/tests/Domain.UnitTests/Please.Domain.UnitTests/Exceptions/DomainExceptionTests.cs
@@ -1,0 +1,36 @@
+using NUnit.Framework;
+using Please.Domain.Exceptions;
+
+namespace Please.Domain.UnitTests.Exceptions;
+
+[TestFixture]
+public class DomainExceptionTests
+{
+    [Test]
+    public void Test_unsupported_provider_message_contains_provider()
+    {
+        var ex = new UnsupportedProviderException("foo");
+        Assert.That(ex.Message, Is.EqualTo("Unsupported provider: foo"));
+    }
+
+    [Test]
+    public void Test_unsupported_model_message_references_provider_and_model()
+    {
+        var ex = new UnsupportedModelException("p", "m");
+        Assert.That(ex.Message, Is.EqualTo("Model 'm' is not supported by provider 'p'"));
+    }
+
+    [Test]
+    public void Test_script_generation_exception_preserves_message()
+    {
+        var ex = new ScriptGenerationException("msg");
+        Assert.That(ex.Message, Is.EqualTo("msg"));
+    }
+
+    [Test]
+    public void Test_script_validation_exception_preserves_message()
+    {
+        var ex = new ScriptValidationException("oops");
+        Assert.That(ex.Message, Is.EqualTo("oops"));
+    }
+}


### PR DESCRIPTION
## Summary
- add Result base type with Success/Failure and mapping helpers
- add StronglyTypedId base record with ScriptId and ProviderId
- cover new classes with unit tests
- add tests for domain exceptions to increase coverage

## Testing
- `dotnet build`
- `dotnet test --collect:"XPlat Code Coverage" --no-build`


------
https://chatgpt.com/codex/tasks/task_e_685658898dc8832199d810c31bc75b47