### PR TITLE
Refine tests and centralize DI

### DIFF
--- a/src/Application/Please.Application/DependencyInjection.cs
+++ b/src/Application/Please.Application/DependencyInjection.cs
@@ -16,6 +16,10 @@ public static class DependencyInjection
         // Register MediatR with all handlers from this assembly
         services.AddMediatR(cfg => cfg.RegisterServicesFromAssembly(Assembly.GetExecutingAssembly()));
 
+        // Register core application services
+        services.AddTransient<IScriptService, ScriptService>();
+        services.AddTransient<CommandProcessor>();
+
         return services;
     }
 }

--- a/src/Presentation/Please.Console/Program.cs
+++ b/src/Presentation/Please.Console/Program.cs
@@ -1,2 +1,10 @@
-﻿// See https://aka.ms/new-console-template for more information
-Console.WriteLine("Hello, World!");
+using Microsoft.Extensions.DependencyInjection;
+using Please.Application;
+
+var services = new ServiceCollection();
+services.AddApplication();
+
+var provider = services.BuildServiceProvider();
+
+// Entry point would resolve command handlers here
+Console.WriteLine("Dependency injection configured.");

--- a/tests/Application.IntegrationTests/Please.Application.IntegrationTests/CommandProcessorIntegrationTests.cs
+++ b/tests/Application.IntegrationTests/Please.Application.IntegrationTests/CommandProcessorIntegrationTests.cs
@@ -4,6 +4,8 @@ using Please.TestUtilities;
 using Please.Domain.Entities;
 using Please.Domain.Enums;
 using Please.Domain.Common;
+using Microsoft.Extensions.DependencyInjection;
+using Please.Application;
 
 namespace Please.Application.IntegrationTests;
 
@@ -19,7 +21,14 @@ public class CommandProcessorIntegrationTests
             NextResult = Result<ScriptResponse>.Success(
                 ScriptResponse.Create("ls", "list", ProviderType.OpenAI, "gpt-4", ScriptType.Bash))
         };
-        var processor = new CommandProcessor(context, generator);
+
+        var services = new ServiceCollection();
+        services.AddApplication();
+        services.AddTransient<IContextService>(_ => context);
+        services.AddTransient<IScriptGenerator>(_ => generator);
+
+        var provider = services.BuildServiceProvider();
+        var processor = provider.GetRequiredService<CommandProcessor>();
 
         var result = await processor.ProcessAsync("list");
 

--- a/tests/Application.IntegrationTests/Please.Application.IntegrationTests/Please.Application.IntegrationTests.csproj
+++ b/tests/Application.IntegrationTests/Please.Application.IntegrationTests/Please.Application.IntegrationTests.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="NUnit" Version="3.14.0" />
     <PackageReference Include="NUnit.Analyzers" Version="3.9.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Application.UnitTests/Please.Application.UnitTests/Please.Application.UnitTests.csproj
+++ b/tests/Application.UnitTests/Please.Application.UnitTests/Please.Application.UnitTests.csproj
@@ -15,6 +15,7 @@
     <PackageReference Include="NUnit" Version="3.14.0" />
     <PackageReference Include="NUnit.Analyzers" Version="3.9.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Application.UnitTests/Please.Application.UnitTests/Services/CommandProcessorTests.cs
+++ b/tests/Application.UnitTests/Please.Application.UnitTests/Services/CommandProcessorTests.cs
@@ -6,6 +6,8 @@ using Please.Domain.Common;
 using Please.Domain.Entities;
 using Please.Domain.Enums;
 using Please.Domain.Interfaces;
+using Microsoft.Extensions.DependencyInjection;
+using Please.Application;
 
 namespace Please.Application.UnitTests.Services;
 
@@ -14,6 +16,7 @@ public class CommandProcessorTests
 {
     private FakeContextService _context = null!;
     private FakeScriptGenerator _generator = null!;
+    private IServiceProvider _provider = null!;
     private CommandProcessor _processor = null!;
 
     [SetUp]
@@ -21,7 +24,14 @@ public class CommandProcessorTests
     {
         _context = new FakeContextService();
         _generator = new FakeScriptGenerator();
-        _processor = new CommandProcessor(_context, _generator);
+
+        var services = new ServiceCollection();
+        services.AddApplication();
+        services.AddTransient<IContextService>(_ => _context);
+        services.AddTransient<IScriptGenerator>(_ => _generator);
+
+        _provider = services.BuildServiceProvider();
+        _processor = _provider.GetRequiredService<CommandProcessor>();
     }
 
     [Test]

--- a/tests/Application.UnitTests/Please.Application.UnitTests/Services/ScriptServiceTests.cs
+++ b/tests/Application.UnitTests/Please.Application.UnitTests/Services/ScriptServiceTests.cs
@@ -5,6 +5,8 @@ using Please.Domain.Common;
 using Please.Domain.Entities;
 using Please.Domain.Enums;
 using Please.Domain.Interfaces;
+using Microsoft.Extensions.DependencyInjection;
+using Please.Application;
 
 namespace Please.Application.UnitTests.Services;
 
@@ -13,14 +15,22 @@ public class ScriptServiceTests
 {
     private FakeScriptGenerator _generator = null!;
     private FakeScriptRepository _repository = null!;
-    private ScriptService _service = null!;
+    private IServiceProvider _provider = null!;
+    private IScriptService _service = null!;
 
     [SetUp]
     public void SetUp()
     {
         _generator = new FakeScriptGenerator();
         _repository = new FakeScriptRepository();
-        _service = new ScriptService(_generator, _repository);
+
+        var services = new ServiceCollection();
+        services.AddApplication();
+        services.AddTransient<IScriptGenerator>(_ => _generator);
+        services.AddTransient<IScriptRepository>(_ => _repository);
+
+        _provider = services.BuildServiceProvider();
+        _service = _provider.GetRequiredService<IScriptService>();
     }
 
     [Test]

--- a/tests/Domain.UnitTests/Please.Domain.UnitTests/Entities/ScriptRequestTests.cs
+++ b/tests/Domain.UnitTests/Please.Domain.UnitTests/Entities/ScriptRequestTests.cs
@@ -8,7 +8,7 @@ namespace Please.Domain.UnitTests.Entities;
 public class ScriptRequestTests
 {
     [Test]
-    public void Create_WithTaskDescription_ShouldSetRequiredProperties()
+    public void script_request_created_with_task_description_sets_required_properties()
     {
         // Arrange
         var taskDescription = "Deploy application to production";
@@ -24,7 +24,7 @@ public class ScriptRequestTests
     }
 
     [Test]
-    public void Create_WithProviderAndModel_ShouldSetAllProperties()
+    public void script_request_created_with_provider_and_model_sets_all_properties()
     {
         // Arrange
         var taskDescription = "Create backup script";
@@ -41,7 +41,7 @@ public class ScriptRequestTests
     }
 
     [Test]
-    public void ScriptRequest_WithWorkingDirectory_ShouldPreserveValue()
+    public void script_request_with_working_directory_preserves_value()
     {
         // Arrange
         var workingDir = "/home/user/projects";

--- a/tests/Domain.UnitTests/Please.Domain.UnitTests/Entities/ScriptResponseTests.cs
+++ b/tests/Domain.UnitTests/Please.Domain.UnitTests/Entities/ScriptResponseTests.cs
@@ -8,7 +8,7 @@ namespace Please.Domain.UnitTests.Entities;
 public class ScriptResponseTests
 {
     [Test]
-    public void RequiresConfirmation_WhenRiskLevelMedium_ShouldReturnTrue()
+    public void requires_confirmation_is_true_when_risk_level_is_medium()
     {
         // Arrange
         var response = ScriptResponse.Create(
@@ -28,7 +28,7 @@ public class ScriptResponseTests
     }
 
     [Test]
-    public void RequiresConfirmation_WhenHasWarnings_ShouldReturnTrue()
+    public void requires_confirmation_is_true_when_response_has_warnings()
     {
         // Arrange
         var response = ScriptResponse.Create(
@@ -48,7 +48,7 @@ public class ScriptResponseTests
     }
 
     [Test]
-    public void RequiresConfirmation_WhenLowRiskNoWarnings_ShouldReturnFalse()
+    public void requires_confirmation_is_false_when_low_risk_and_no_warnings()
     {
         // Arrange
         var response = ScriptResponse.Create(
@@ -68,7 +68,7 @@ public class ScriptResponseTests
     }
 
     [Test]
-    public void IsDangerous_WhenRiskLevelHigh_ShouldReturnTrue()
+    public void is_dangerous_is_true_when_risk_level_is_high()
     {
         // Arrange
         var response = ScriptResponse.Create(
@@ -88,7 +88,7 @@ public class ScriptResponseTests
     }
 
     [Test]
-    public void WithWarning_ShouldAddWarningToList()
+    public void with_warning_adds_warning_to_list()
     {
         // Arrange
         var response = ScriptResponse.Create(
@@ -108,7 +108,7 @@ public class ScriptResponseTests
     }
 
     [Test]
-    public void WithSafetyNote_ShouldAddNoteToList()
+    public void with_safety_note_adds_note_to_list()
     {
         // Arrange
         var response = ScriptResponse.Create(

--- a/tests/Domain.UnitTests/Please.Domain.UnitTests/Exceptions/DomainExceptionTests.cs
+++ b/tests/Domain.UnitTests/Please.Domain.UnitTests/Exceptions/DomainExceptionTests.cs
@@ -14,7 +14,7 @@ public class DomainExceptionTests
     }
 
     [Test]
-    public void unsupported_model_message_references_the_provider_and_model()
+    public void unsupported_model_message_references_provider_and_model()
     {
         var ex = new UnsupportedModelException("p", "m");
         Assert.That(ex.Message, Is.EqualTo("Model 'm' is not supported by provider 'p'"));


### PR DESCRIPTION
## Summary
- centralize DI setup in `AddApplication`
- wire DI in console `Program`
- reuse DI setup in tests
- drop `Test_` prefix from test names for readability

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685668f92f148321b7763bffc8760273