### PR TITLE
Implement TestModule pattern for AOT tests

### DIFF
--- a/memory-bank/native-aot-compatibility-for-tests.md
+++ b/memory-bank/native-aot-compatibility-for-tests.md
@@ -16,7 +16,7 @@ This document outlines the strategies and patterns implemented to ensure test co
 
 ### TestSystem.cs Changes
 
-The `TestSystem.cs` file was updated to use direct registration of interfaces instead of factory methods:
+The `TestSystem.cs` file now leverages a `TestModule` with an `AddTestDoubles` extension method to centralize registration of common fakes:
 
 ```csharp
 public static class TestSystem
@@ -25,15 +25,7 @@ public static class TestSystem
     {
         return PleaseHost.CreateServiceProvider(services =>
         {
-            // Register test doubles with explicit interface implementations for AOT compatibility
-            services.AddSingleton<FakeScriptGenerator>();
-            services.AddSingleton<FakeScriptRepository>();
-            services.AddSingleton<FakeContextService>();
-
-            // Use direct registration instead of factory methods for AOT compatibility
-            services.AddSingleton<IScriptGenerator, FakeScriptGenerator>();
-            services.AddSingleton<IScriptRepository, FakeScriptRepository>();
-            services.AddSingleton<IContextService, FakeContextService>();
+            services.AddTestDoubles();
 
             services.AddLogging(builder => builder.AddDebug());
             configure?.Invoke(services);
@@ -57,19 +49,8 @@ Example from ScriptServiceTests.cs:
 ```csharp
 public ScriptServiceTests()
 {
-    // Create a test service provider with explicit configuration for AOT compatibility
-    var provider = TestSystem.Create(services =>
-    {
-        // Ensure the test doubles are properly configured
-        services.AddSingleton<FakeScriptGenerator>();
-        services.AddSingleton<FakeScriptRepository>();
-        services.AddSingleton<FakeContextService>();
-
-        // Register interfaces with their implementations
-        services.AddSingleton<IScriptGenerator>(sp => sp.GetRequiredService<FakeScriptGenerator>());
-        services.AddSingleton<IScriptRepository>(sp => sp.GetRequiredService<FakeScriptRepository>());
-        services.AddSingleton<IContextService>(sp => sp.GetRequiredService<FakeContextService>());
-    });
+    // Create a test service provider with all test doubles pre-registered
+    var provider = TestSystem.Create();
 
     _generator = provider.GetRequiredService<FakeScriptGenerator>();
     _repository = provider.GetRequiredService<FakeScriptRepository>();

--- a/memory-bank/strategic-testing-c#-migration-progress.md
+++ b/memory-bank/strategic-testing-c#-migration-progress.md
@@ -13,6 +13,7 @@ Implement the minimal set of high-value tests that enable confident refactoring 
 - ✅ Result pattern and strongly typed IDs implemented with unit tests
 - ✅ **Native AOT Compatibility**: Tests updated to work with Native AOT compilation
 - 🔄 **Test Refactoring**: [Roadmap created](native-aot-test-refactoring-roadmap.md) for enterprise-grade improvements
+- ✅ **TestModule Pattern**: Centralized registration of test doubles
 
 ### 2. Strategic Domain Tests (9 tests passing)
 **File**: `tests/Domain.UnitTests/Please.Domain.UnitTests/Entities/ScriptRequestTests.cs`

--- a/tests/Application.IntegrationTests/Please.Application.IntegrationTests/CommandProcessorIntegrationTests.cs
+++ b/tests/Application.IntegrationTests/Please.Application.IntegrationTests/CommandProcessorIntegrationTests.cs
@@ -28,13 +28,9 @@ public class CommandProcessorIntegrationTests
 
         var provider = PleaseHost.CreateServiceProvider(services =>
         {
-            // Register test doubles with explicit interface implementations for AOT compatibility
+            services.AddTestDoubles();
             services.AddSingleton<IContextService>(_ => context);
             services.AddSingleton<IScriptGenerator>(_ => generator);
-
-            // Register required repository for AOT compatibility
-            services.AddSingleton<FakeScriptRepository>();
-            services.AddSingleton<IScriptRepository>(sp => sp.GetRequiredService<FakeScriptRepository>());
         });
         var processor = provider.GetRequiredService<CommandProcessor>();
 

--- a/tests/Application.IntegrationTests/Please.Application.IntegrationTests/ScriptGenerationIntegrationTests.cs
+++ b/tests/Application.IntegrationTests/Please.Application.IntegrationTests/ScriptGenerationIntegrationTests.cs
@@ -20,6 +20,8 @@ public class ScriptGenerationIntegrationTests
     {
         _serviceProvider = PleaseHost.CreateServiceProvider(services =>
         {
+            services.AddTestDoubles();
+
             // Register real implementations - this tests actual behavior
             services.AddTransient<IScriptValidationService, TestScriptValidationService>();
             services.AddTransient<IScriptGenerator, TestScriptGenerator>();
@@ -28,8 +30,6 @@ public class ScriptGenerationIntegrationTests
             services.AddSingleton(testRepo);
             services.AddTransient<GenerateScriptCommandHandler>();
 
-            // Register required services for AOT compatibility
-            services.AddSingleton<FakeContextService>();
             services.AddSingleton<IContextService>(sp => sp.GetRequiredService<FakeContextService>());
         });
         _handler = _serviceProvider.GetRequiredService<GenerateScriptCommandHandler>();

--- a/tests/Application.UnitTests/Please.Application.UnitTests/PleaseHostTests.cs
+++ b/tests/Application.UnitTests/Please.Application.UnitTests/PleaseHostTests.cs
@@ -15,15 +15,7 @@ public class PleaseHostTests
         // Register all required dependencies for AOT compatibility
         var provider = PleaseHost.CreateServiceProvider(services =>
         {
-            // Register test doubles
-            services.AddSingleton<FakeScriptGenerator>();
-            services.AddSingleton<FakeScriptRepository>();
-            services.AddSingleton<FakeContextService>();
-
-            // Register interfaces
-            services.AddSingleton<IScriptGenerator>(sp => sp.GetRequiredService<FakeScriptGenerator>());
-            services.AddSingleton<IScriptRepository>(sp => sp.GetRequiredService<FakeScriptRepository>());
-            services.AddSingleton<IContextService>(sp => sp.GetRequiredService<FakeContextService>());
+            services.AddTestDoubles();
         });
 
         object? service = provider.GetService(typeof(IScriptService));
@@ -36,14 +28,8 @@ public class PleaseHostTests
         var fake = new FakeScriptGenerator();
         var provider = PleaseHost.CreateServiceProvider(services =>
         {
-            // Register the fake generator
+            services.AddTestDoubles();
             services.AddSingleton<IScriptGenerator>(fake);
-
-            // Register other required dependencies
-            services.AddSingleton<FakeScriptRepository>();
-            services.AddSingleton<FakeContextService>();
-            services.AddSingleton<IScriptRepository>(sp => sp.GetRequiredService<FakeScriptRepository>());
-            services.AddSingleton<IContextService>(sp => sp.GetRequiredService<FakeContextService>());
         });
 
         var resolved = provider.GetRequiredService<IScriptGenerator>();

--- a/tests/Application.UnitTests/Please.Application.UnitTests/Services/CommandProcessorTests.cs
+++ b/tests/Application.UnitTests/Please.Application.UnitTests/Services/CommandProcessorTests.cs
@@ -18,19 +18,7 @@ public class CommandProcessorTests
 
     public CommandProcessorTests()
     {
-        // Create a test service provider with explicit configuration for AOT compatibility
-        var provider = TestSystem.Create(services =>
-        {
-            // Ensure the test doubles are properly configured
-            services.AddSingleton<FakeScriptGenerator>();
-            services.AddSingleton<FakeScriptRepository>();
-            services.AddSingleton<FakeContextService>();
-
-            // Register interfaces with their implementations
-            services.AddSingleton<IScriptGenerator>(sp => sp.GetRequiredService<FakeScriptGenerator>());
-            services.AddSingleton<IScriptRepository>(sp => sp.GetRequiredService<FakeScriptRepository>());
-            services.AddSingleton<IContextService>(sp => sp.GetRequiredService<FakeContextService>());
-        });
+        var provider = TestSystem.Create();
 
         _context = provider.GetRequiredService<FakeContextService>();
         _generator = provider.GetRequiredService<FakeScriptGenerator>();

--- a/tests/Application.UnitTests/Please.Application.UnitTests/Services/ScriptServiceTests.cs
+++ b/tests/Application.UnitTests/Please.Application.UnitTests/Services/ScriptServiceTests.cs
@@ -17,19 +17,7 @@ public class ScriptServiceTests
 
     public ScriptServiceTests()
     {
-        // Create a test service provider with explicit configuration for AOT compatibility
-        var provider = TestSystem.Create(services =>
-        {
-            // Ensure the test doubles are properly configured
-            services.AddSingleton<FakeScriptGenerator>();
-            services.AddSingleton<FakeScriptRepository>();
-            services.AddSingleton<FakeContextService>();
-
-            // Register interfaces with their implementations
-            services.AddSingleton<IScriptGenerator>(sp => sp.GetRequiredService<FakeScriptGenerator>());
-            services.AddSingleton<IScriptRepository>(sp => sp.GetRequiredService<FakeScriptRepository>());
-            services.AddSingleton<IContextService>(sp => sp.GetRequiredService<FakeContextService>());
-        });
+        var provider = TestSystem.Create();
 
         _generator = provider.GetRequiredService<FakeScriptGenerator>();
         _repository = provider.GetRequiredService<FakeScriptRepository>();

--- a/tests/TestUtilities/Please.TestUtilities/TestModule.cs
+++ b/tests/TestUtilities/Please.TestUtilities/TestModule.cs
@@ -1,0 +1,20 @@
+using Microsoft.Extensions.DependencyInjection;
+using Please.Domain.Interfaces;
+
+namespace Please.TestUtilities;
+
+public static class TestModule
+{
+    public static IServiceCollection AddTestDoubles(this IServiceCollection services)
+    {
+        services.AddSingleton<FakeScriptGenerator>();
+        services.AddSingleton<FakeScriptRepository>();
+        services.AddSingleton<FakeContextService>();
+
+        services.AddSingleton<IScriptGenerator>(sp => sp.GetRequiredService<FakeScriptGenerator>());
+        services.AddSingleton<IScriptRepository>(sp => sp.GetRequiredService<FakeScriptRepository>());
+        services.AddSingleton<IContextService>(sp => sp.GetRequiredService<FakeContextService>());
+
+        return services;
+    }
+}

--- a/tests/TestUtilities/Please.TestUtilities/TestSystem.cs
+++ b/tests/TestUtilities/Please.TestUtilities/TestSystem.cs
@@ -11,15 +11,7 @@ public static class TestSystem
     {
         return PleaseHost.CreateServiceProvider(services =>
         {
-            // Register test doubles with explicit interface implementations for AOT compatibility
-            services.AddSingleton<FakeScriptGenerator>();
-            services.AddSingleton<FakeScriptRepository>();
-            services.AddSingleton<FakeContextService>();
-
-            // Use direct registration instead of factory methods for AOT compatibility
-            services.AddSingleton<IScriptGenerator, FakeScriptGenerator>();
-            services.AddSingleton<IScriptRepository, FakeScriptRepository>();
-            services.AddSingleton<IContextService, FakeContextService>();
+            services.AddTestDoubles();
 
             services.AddLogging(builder => builder.AddDebug());
             configure?.Invoke(services);


### PR DESCRIPTION
## Summary
- centralize fake registrations with `TestModule.AddTestDoubles`
- update `TestSystem` to use `AddTestDoubles`
- simplify application unit/integration tests to use the module
- document new approach in the native AOT compatibility guide
- record progress in strategic testing document

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_685a729f57b883219f3ab47b8adb76d9